### PR TITLE
Add unit test for Contact_Details response

### DIFF
--- a/lib/response/contact/details.php
+++ b/lib/response/contact/details.php
@@ -1,6 +1,6 @@
 <?php declare( strict_types=1 );
 
-namespace Automattic\Domain_Services\Response\Internal\Contact;
+namespace Automattic\Domain_Services\Response\Contact;
 
 use Automattic\Domain_Services\{Entity, Response};
 
@@ -20,7 +20,7 @@ class Details implements Response\Response_Interface {
 	 */
 	public function get_contact_information(): Entity\Contact_Information {
 		$contact_information_data = $this->get_data_by_key( self::CONTACT_INFORMATION );
-		return new Entity\Contact_Information::from_array( $contact_information_data );
+		return Entity\Contact_Information::from_array( $contact_information_data );
 	}
 
 	/**

--- a/lib/response/factory.php
+++ b/lib/response/factory.php
@@ -24,7 +24,7 @@ class Factory {
 
 		$class_name = __NAMESPACE__ . '\\' . $class_name;
 		if ( ! class_exists( $class_name ) ) {
-			throw new Exception\Domain_Services_Exception( 'Missing response class: ' . $class_name );
+			throw new Exception\Domain_Services_Exception( Code::INVALID_COMMAND_NAME, ['message' => 'Missing response class: ' . $class_name] );
 		}
 
 		return new $class_name( $response );

--- a/test/lib/domain-services-client-test-case.php
+++ b/test/lib/domain-services-client-test-case.php
@@ -12,7 +12,7 @@ class Domain_Services_Client_Test_Case extends \PHPUnit\Framework\TestCase {
 		$this->response_factory = new Response\Factory();
 	}
 
-	public function assertIsValidResponse( array $expected_data, Response\Event\Ack $response ): void {
+	public function assertIsValidResponse( array $expected_data, Response\Response_Interface $response ): void {
 		$this->assertInstanceOf( Response\Response_Interface::class, $response );
 
 		$this->assertIsString( $response->get_server_txn_id() );

--- a/test/lib/mocks/response-data.php
+++ b/test/lib/mocks/response-data.php
@@ -212,6 +212,36 @@ function get_mock_response( Command\Command_Interface $command, ?string $domain,
 			];
 			break;
 
+		case 'Contact_Details-success':
+			$response = [
+				'status' => 200,
+				'status_description' => 'Command completed successfully',
+				'success' => true,
+				'client_txn_id' => 'test-client-transaction-id',
+				'server_txn_id' => '5ffdba44-eeec-4647-9cc4-27cdf8352efc.local-isolated-test-request',
+				'timestamp' => 1669075517,
+				'runtime' => 0.0019,
+				'data' => [
+					'contact_information' => [
+						'first_name' => 'John',
+						'last_name' => 'Doe',
+						'organization' => '',
+						'address_1' => 'Avenida dos Bandeirantes 123',
+						'address_2' => 'Apto 12',
+						'postal_code' => '12345-678',
+						'city' => 'Sao Paulo',
+						'state' => '',
+						'country_code' => 'BR',
+						'email' => 'john.doe@automattic.com',
+						'phone' => '+55.11987654321',
+						'fax' => '',
+					],
+					'validated' => true,
+					'verified' => false,
+				],
+			];
+			break;
+
 		default:
 			throw new \RuntimeException( 'Unknown command used in mock response request' );
 	}

--- a/test/response/contact-details-test.php
+++ b/test/response/contact-details-test.php
@@ -1,0 +1,24 @@
+<?php declare( strict_types=1 );
+
+namespace Automattic\Domain_Services\Test;
+
+use Automattic\Domain_Services\{Command, Entity, Mock, Response};
+
+class Contact_Details_Test extends Domain_Services_Client_Test_Case {
+	public function test_response_factory_success(): void {
+		$contact_id = new Entity\Contact_Id( 'SP1:P-ABC2134' );
+		$command = new Command\Contact\Details( $contact_id );
+
+		$response_data = get_mock_response( $command, null, 'success' );
+
+		/** @var Response\Contact\Details $response_object */
+		$response_object = $this->response_factory->build_response( $command, $response_data );
+
+		$this->assertInstanceOf( Response\Contact\Details::class, $response_object );
+
+		$this->assertIsValidResponse( $response_data, $response_object );
+
+		$contact_information = $response_object->get_contact_information()->to_array();
+		$this->assertSame( $response_data['data']['contact_information'], $contact_information );
+	}
+}

--- a/test/response/dns-records-set-test.php
+++ b/test/response/dns-records-set-test.php
@@ -57,3 +57,4 @@ class Dns_Records_Set_Test extends Domain_Services_Client_Test_Case {
 		$this->assertCount( 2, $response_dns_deleted_record_sets_data );
 	}
 }
+


### PR DESCRIPTION
This PR adds a unit test for the response from the Comtact_Details command.

It also fixes a couple bugs in the response factory and the assertIsValidResponse method.

You can run the unit tests with:

```
composer install
./vendor/bin/phpunit -c ./test/phpunit.xml
```