### PR TITLE
Adding unit tests for the Domain_Check response

### DIFF
--- a/lib/entity/domain-names.php
+++ b/lib/entity/domain-names.php
@@ -15,6 +15,16 @@ class Domain_Names {
 	}
 
 	/**
+	 * @param Domain_name $domain_name
+	 * @return $this
+	 */
+	public function add_domain_name( Domain_name $domain_name ): self {
+		$this->domain_names[] = $domain_name;
+
+		return $this;
+	}
+
+	/**
 	 * @return Domain_Name[]
 	 */
 	public function get_domain_names(): array {

--- a/lib/response/domain/check.php
+++ b/lib/response/domain/check.php
@@ -7,45 +7,12 @@ use Automattic\Domain_Services\Response;
 class Check implements Response\Response_Interface {
 	use Response\Data_Trait;
 
-	public const DOMAINS = 'domains';
-
-	// Availability data
-	public const AVAILABLE = 'available';
-	public const FEE_CLASS = 'fee_class';
-	public const FEE_AMOUNT = 'fee_amount';
-
-	// Fee amount specific (premium domains only)
-	public const FEE_AMOUNT_NEW = 'fee_amount_new';
-	public const FEE_AMOUNT_RENEWAL = 'fee_amount_renewal';
-	public const FEE_AMOUNT_TRANSFER = 'fee_amount_transfer';
-
 	/**
 	 * Gets the availability information for a list of domain from the response.
 	 *
 	 * @return array
 	 */
-	public function get_domain(): array {
+	public function get_domains(): array {
 		return $this->get_data_by_key( 'data.domains' ) ?? [];
 	}
 }
-
-//'domains' =>
-//  array (
-//	  'test-mock-domain-01.com' =>
-//		  array (
-//			  'available' => true,
-//			  'fee_class' => 'standard',
-//		  ),
-//	  'test-mock-domain-02.com' =>
-//		  array (
-//			  'available' => true,
-//			  'fee_class' => 'standard',
-//		  ),
-//  ),
-//  'status' => 200,
-//  'status_description' => 'Command completed successfully',
-//  'success' => true,
-//  'client_txn_id' => 'test-client-transaction-id',
-//  'server_txn_id' => '5a665a0f-32eb-4882-8c19-0bb28b6c35fc.local-isolated-test-request',
-//  'timestamp' => 1667777790,
-//  'runtime' => 0.0002,

--- a/test/lib/mocks/response-data.php
+++ b/test/lib/mocks/response-data.php
@@ -242,6 +242,34 @@ function get_mock_response( Command\Command_Interface $command, ?string $domain,
 			];
 			break;
 
+		case 'Domain_Check-success':
+			$response = [
+				'status' => 200,
+				'status_description' => 'Command completed successfully',
+				'success' => true,
+				'client_txn_id' => 'test-client-transaction-id',
+				'server_txn_id' => '3b581197-d93a-466a-957d-3569cb28279c.local-isolated-test-request',
+				'timestamp' => 1669075519,
+				'runtime' => 0.0013,
+				'data' => [
+					'domains' => [
+						'test-domain-name-1.com' => [
+							'available' => true,
+							'fee_class' => 'standard',
+						],
+						'test-domain-name-2.com' => [
+							'available' => true,
+							'fee_class' => 'standard',
+						],
+						'test-domain-name-3.com' => [
+							'available' => false,
+							'fee_class' => 'standard',
+						],
+					],
+				],
+			];
+			break;
+
 		default:
 			throw new \RuntimeException( 'Unknown command used in mock response request' );
 	}

--- a/test/response/domain-check-test.php
+++ b/test/response/domain-check-test.php
@@ -1,0 +1,28 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\Domain_Services\Test;
+
+use Automattic\Domain_Services\{Command, Entity, Mock, Response};
+
+class Domain_Check_Test extends Domain_Services_Client_Test_Case {
+	public function test_response_factory_success(): void {
+		$domain_names = new Entity\Domain_Names();
+		$domain_names->add_domain_name( new Entity\Domain_Name( 'test-domain-name-1.com' ) )
+			->add_domain_name( new Entity\Domain_Name( 'test-domain-name-2.com' ) )
+			->add_domain_name( new Entity\Domain_Name( 'test-domain-name-3.com' ) );
+		$command = new Command\Domain\Check( $domain_names );
+
+		$response_data = get_mock_response( $command, null, 'success' );
+
+		/** @var Response\Domain\Check $response_object */
+		$response_object = $this->response_factory->build_response( $command, $response_data );
+
+		$this->assertInstanceOf( Response\Domain\Check::class, $response_object );
+
+		$this->assertIsValidResponse( $response_data, $response_object );
+
+		$availability_data = $response_object->get_domains();
+		$this->assertSame( $response_data['data']['domains'], $availability_data );
+	}
+}


### PR DESCRIPTION
This PR adds unit tests for the Domain_Check responses

It also adds what seems like a missing `add_domain()` to method to the `Domain_Names` class and removes a bunch of unused data from the response class

You can run the unit tests like this:

```
composer install
./vendor/bin/phpunit -c ./test/phpunit.xml
```