### PR TITLE
Add unit test for the Domain_Renew response

### DIFF
--- a/lib/response/domain/renew.php
+++ b/lib/response/domain/renew.php
@@ -2,12 +2,13 @@
 
 namespace Automattic\Domain_Services\Response\Domain;
 
-use Automattic\Domain_Services\Response;
+use Automattic\Domain_Services\{Entity, Response};
 
 class Renew implements Response\Response_Interface {
 	use Response\Data_Trait;
 
-	public function get_expiration_date(): ?string {
-		return $this->get_data_by_key( 'data.expiration_date' );
+	public function get_expiration_date(): ?\DateTimeImmutable {
+		$expiration_date = $this->get_data_by_key( 'data.expiration_date' );
+		return null === $expiration_date ? null : \DateTimeImmutable::createFromFormat( Entity\Entity_Interface::DATE_FORMAT, $expiration_date );
 	}
 }

--- a/test/response/domain-renew-test.php
+++ b/test/response/domain-renew-test.php
@@ -1,0 +1,34 @@
+<?php declare( strict_types=1 );
+
+namespace Automattic\Domain_Services\Test\Response;
+
+use Automattic\Domain_Services\{Command, Entity, Response, Test};
+
+class Domain_Renew_Test extends Test\Lib\Domain_Services_Client_Test_Case {
+	public function test_response_factory_success(): void {
+		$domain_name = new Entity\Domain_Name( 'test-domain-name.com' );
+		$command = new Command\Domain\Renew( $domain_name, 2022, 1, null );
+
+		$response_data = [
+			'data' => [
+				'expiration_date' => '2024-06-30 12:00:00',
+			],
+			'status' => 200,
+			'status_description' => 'Command completed successfully',
+			'success' => true,
+			'client_txn_id' => 'test-client-transaction-id',
+			'server_txn_id' => '3c933e3a-959c-4646-85f2-612f69450a35.local-isolated-test-request',
+			'timestamp' => 1669075524,
+			'runtime' => 0.0059,
+		];
+
+		/** @var Response\Domain\Renew $response_object */
+		$response_object = $this->response_factory->build_response( $command, $response_data );
+
+		$this->assertInstanceOf( Response\Domain\Renew::class, $response_object );
+
+		$this->assertIsValidResponse( $response_data, $response_object );
+
+		$this->assertSame( $response_data['data']['expiration_date'], $response_object->get_expiration_date()->format( Entity\Entity_Interface::DATE_FORMAT ) );
+	}
+}


### PR DESCRIPTION
This PR adds a unit test for the response from the Domain_Renew command and updates the return type of the expiration date for this object to be a DateTimeImmutable.

Run the unit tests:
```
composer install
./vendor/bin/phpunit -c ./test/phpunit.xml
```
