### PR TITLE
Sync changes from the WPCOM entities to the client

### DIFF
--- a/lib/entity/dns-record-sets.php
+++ b/lib/entity/dns-record-sets.php
@@ -2,8 +2,6 @@
 
 namespace Automattic\Domain_Services\Entity;
 
-use Automattic\Domain_Services\{Exception};
-
 class Dns_Record_Sets implements \Iterator {
 	/**
 	 * The list of EPP status codes that apply to a single domain

--- a/lib/entity/reseller-event.php
+++ b/lib/entity/reseller-event.php
@@ -205,7 +205,7 @@ class Reseller_Event {
 	 */
 	public static function from_array( array $data ): self {
 		$reseller_event = new self();
-		$event_data = json_decode( $data[ self::EVENT_DATA ], true, 512, JSON_THROW_ON_ERROR );
+		$event_data = json_decode( $data[ self::EVENT_DATA ] ?? '[]', true, 512, JSON_THROW_ON_ERROR );
 		$created_date = \DateTimeImmutable::createFromFormat( Entity_Interface::DATE_FORMAT, $data[ self::CREATED_DATE ] );
 		$acknowledged_date = null === $data[ self::ACKNOWLEDGED_DATE ] ? null : \DateTimeImmutable::createFromFormat( Entity_Interface::DATE_FORMAT, $data[ self::ACKNOWLEDGED_DATE ] );
 


### PR DESCRIPTION
We have two minor changes to the entities classes that were made in the server repo that had not been synced to the client repo. This PR just does this syncing.

Make sure the unit tests still run properly:

```
composer install
./vendor/bin/phpunit -c ./test/phpunit.xml
```