### PR TITLE
Update the Dns_Records_* responses to use the new from_array() method

### DIFF
--- a/lib/response/dns/records/get.php
+++ b/lib/response/dns/records/get.php
@@ -11,9 +11,8 @@ class Get implements Response\Response_Interface {
 	use Response\Data_Trait;
 
 	public function get_dns_records(): Entity\Dns_Records {
-		$domain_name_data = $this->get_data_by_key( 'data.dns_records.domain' );
-		$record_sets_data = $this->get_data_by_key( 'data.dns_records.record_sets' );
+		$dns_records_data = $this->get_data_by_key( 'data.dns_records' );
 
-		return Entity\Dns_Records::from_array( $domain_name_data, $record_sets_data );
+		return Entity\Dns_Records::from_array( $dns_records_data );
 	}
 }

--- a/lib/response/dns/records/set.php
+++ b/lib/response/dns/records/set.php
@@ -17,16 +17,26 @@ class Set implements Response\Response_Interface {
 
 	public function get_records_added(): Entity\Dns_Records {
 		$domain_name_data = $this->get_data_by_key( 'data.change_set.domain' );
-		$record_sets_data = $this->get_data_by_key( 'data.change_set.records_added' );
+		$records_added_data = $this->get_data_by_key( 'data.change_set.records_added' );
 
-		return Entity\Dns_Records::from_array( $domain_name_data, $record_sets_data );
+		return Entity\Dns_Records::from_array(
+			[
+				'domain' => $domain_name_data,
+				'record_sets' => $records_added_data,
+			]
+		);
 	}
 
 	public function get_records_deleted(): Entity\Dns_Records {
 		$domain_name_data = $this->get_data_by_key( 'data.change_set.domain' );
-		$record_sets_data = $this->get_data_by_key( 'data.change_set.records_deleted' );
+		$records_deleted_data = $this->get_data_by_key( 'data.change_set.records_deleted' );
 
-		return Entity\Dns_Records::from_array( $domain_name_data, $record_sets_data );
+		return Entity\Dns_Records::from_array(
+			[
+				'domain' => $domain_name_data,
+				'record_sets' => $records_deleted_data,
+			]
+		);
 	}
 }
 


### PR DESCRIPTION
We updated the Dns_Records::from_array() method to use only an array.  This PR updates the Dns_Records_* response classes to use the new method signature.

Run the unit tests:
```
composer install
./vendor/bin/phpunit -c ./test/phpunit.xml
```