### PR TITLE
Add unit test for the Domain_Transferlock_Set command

### DIFF
--- a/test/command/domain-transferlock-set-test.php
+++ b/test/command/domain-transferlock-set-test.php
@@ -1,0 +1,30 @@
+<?php declare( strict_types=1 );
+
+namespace Automattic\Domain_Services\Test\Command;
+
+use Automattic\Domain_Services\{Command, Entity, Test};
+
+class Domain_Transferlock_Set_Test extends Test\Lib\Domain_Services_Client_Test_Case {
+	use Command\Array_Key_Domain_Trait, Command\Array_Key_Transferlock_Trait;
+
+	public function test_command_instance_success(): void {
+		$mock_command_data = [
+			Command\Command_Interface::COMMAND => 'Domain_Transferlock_Set',
+			Command\Command_Interface::PARAMS => [
+				self::get_domain_name_array_key() => 'test-domain-name.com',
+				self::get_transferlock_array_key() => true,
+			],
+			Command\Command_Interface::CLIENT_TXN_ID => 'client-transaction-info-for-domain-transferlock-set-test-1',
+		];
+
+		$domain = new Entity\Domain_Name( $mock_command_data[ Command\Command_Interface::PARAMS ][ self::get_domain_name_array_key() ] );
+		$command = new Command\Domain\Transferlock\Set( $domain, $mock_command_data[ Command\Command_Interface::PARAMS ][ self::get_transferlock_array_key() ] );
+		$command->set_client_txn_id( $mock_command_data[ Command\Command_Interface::CLIENT_TXN_ID ] );
+
+		$this->assertInstanceOf( Command\Domain\Transferlock\Set::class, $command );
+
+		$actual_command_array = $command->jsonSerialize();
+
+		$this->assertSame( $mock_command_data, $actual_command_array );
+	}
+}


### PR DESCRIPTION
Adding a unit test for the Domain_Transferlock_Set command

Run the unit tests:
```
composer install
./vendor/bin/phpunit -c ./test/phpunit.xml
```