### PR TITLE
Add object type traits to the events

### DIFF
--- a/lib/event/contact/verification/notify.php
+++ b/lib/event/contact/verification/notify.php
@@ -8,7 +8,7 @@ use Automattic\Domain_Services\{Event};
  * This event indicates a change in the contact status
  */
 class Notify implements Event\Event_Interface {
-	use Event\Data_Trait;
+	use Event\Data_Trait, Event\Object_Type_Contact_Trait;
 
 	/**
 	 * Returns tha verification status of the contact.

--- a/lib/event/contact/verification/request.php
+++ b/lib/event/contact/verification/request.php
@@ -8,7 +8,7 @@ use Automattic\Domain_Services\{Event};
  * This event indicates that a verification request was sent to the contact's email address.
  */
 class Request implements Event\Event_Interface {
-	use Event\Data_Trait;
+	use Event\Data_Trait, Event\Object_Type_Contact_Trait;
 
 	/**
 	 * Returns the email address that the verification request was sent to.

--- a/lib/event/domain/contacts/set/success.php
+++ b/lib/event/domain/contacts/set/success.php
@@ -2,8 +2,13 @@
 
 namespace Automattic\Domain_Services\Event\Domain\Contacts\Set;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services\{Entity, Event};
 
 class Success implements Event\Event_Interface {
-	use Event\Data_Trait;
+	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+
+	public function get_contacts(): Entity\Domain_Contacts {
+		$contact_data = $this->get_data_by_key( 'event_data.contacts' ) ?? [];
+		return Entity\Domain_Contacts::from_array( $contact_data );
+	}
 }

--- a/lib/event/object-type-contact-trait.php
+++ b/lib/event/object-type-contact-trait.php
@@ -1,0 +1,11 @@
+<?php declare( strict_types=1 );
+
+namespace Automattic\Domain_Services\Event;
+
+use Automattic\Domain_Services\{Entity};
+
+trait Object_Type_Contact_Trait {
+	final public function get_contact_id(): Entity\Contact_Id {
+		return new Entity\Contact_Id( $this->get_object_id() );
+	}
+}

--- a/lib/event/object-type-domain-trait.php
+++ b/lib/event/object-type-domain-trait.php
@@ -1,0 +1,11 @@
+<?php declare( strict_types=1 );
+
+namespace Automattic\Domain_Services\Event;
+
+use Automattic\Domain_Services\{Entity};
+
+trait Object_Type_Domain_Trait {
+	final public function get_domain(): Entity\Domain_Name {
+		return new Entity\Domain_Name( $this->get_object_id() );
+	}
+}

--- a/test/event/contact-verification-request-test.php
+++ b/test/event/contact-verification-request-test.php
@@ -23,8 +23,8 @@ class Contact_Verification_Request_Test extends Test\Lib\Domain_Services_Client_
 					'event_subclass' => 'Request',
 					'object_type' => 'contact',
 					'object_id' => 'SP1:P-ABC1234',
-					'created_date' => '2022-01-23 12:34:56',
-					'acknowldeged_date' => null,
+					'event_date' => '2022-01-23 12:34:56',
+					'acknowledged_date' => null,
 					'event_data' => [
 						'email' => 'registrant@example.com',
 						'verification_code' => 'qwerty12345',
@@ -43,5 +43,6 @@ class Contact_Verification_Request_Test extends Test\Lib\Domain_Services_Client_
 
 		$this->assertInstanceOf( Event\Contact\Verification\Request::class, $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['email'], $event->get_email() );
+		$this->assertSame( $response_data['data']['event']['object_id'], (string) $event->get_contact_id() );
 	}
 }


### PR DESCRIPTION
This PR adds object type traits to the events to retrieve an entity of the correct type based on the object_type of the event.

Run the unit tests:
```
composer install
./vendor/bin/phpunit -c ./test/phpunit.xml
```