### PR TITLE
Remove contact data from the Domain_Contacts_Set response

### DIFF
--- a/lib/response/domain/contacts/set.php
+++ b/lib/response/domain/contacts/set.php
@@ -6,9 +6,4 @@ use Automattic\Domain_Services\{Entity, Response};
 
 class Set implements Response\Response_Interface {
 	use Response\Data_Trait;
-
-	public function get_contacts(): Entity\Domain_Contacts {
-		$contact_data = $this->get_data_by_key( 'data.contacts' ) ?? [];
-		return Entity\Domain_Contacts::from_array( $contact_data );
-	}
 }

--- a/test/api/api-test.php
+++ b/test/api/api-test.php
@@ -69,11 +69,6 @@ class ApiTest extends Test\Lib\Domain_Services_Client_Test_Case {
 			$this->assertEquals( $mock_response_array['runtime'], $response->get_runtime() );
 			$this->assertEquals( $mock_response_array['timestamp'], $response->get_timestamp() );
 			$this->assertEquals( $mock_response_array['server_txn_id'], $response->get_server_txn_id() );
-
-			$contact_id_parts = explode( ':', $mock_response_array['data']['contacts']['owner']['contact_id'] );
-
-			$this->assertEquals( $contact_id_parts[0], $response->get_contacts()->get_owner()->get_contact_id()->get_provider_id() );
-			$this->assertEquals( $contact_id_parts[1], $response->get_contacts()->get_owner()->get_contact_id()->get_provider_contact_id() );
 		} catch ( \Automattic\Domain_Services\Exception\Domain_Services_Exception $e ) {
 			echo 'Exception when calling Domain_Contacts_Set: ', $e->getMessage(), PHP_EOL;
 			var_dump( $e->getCode() );

--- a/test/response/domain-contacts-set-test.php
+++ b/test/response/domain-contacts-set-test.php
@@ -38,20 +38,7 @@ class Domain_Contacts_Set_Test extends Test\Lib\Domain_Services_Client_Test_Case
 			'server_txn_id' => 'bf091ce4-bca4-4f8e-8d65-30f37d13609d.local-isolated-test-request',
 			'timestamp' => 1669075519,
 			'runtime' => 0.0104,
-			'data' => [
-				'contacts' => [
-					'owner' => [
-						'contact_id' => 'SP1:P-ABC1234',
-						'contact_information' => $contact_info,
-						'contact_disclosure' => 'none',
-					],
-					'admin' => [
-						'contact_id' => 'SP1:P-XYZ5678',
-						'contact_information' => $contact_info,
-						'contact_disclosure' => 'none',
-					],
-				],
-			],
+			'data' => [],
 		];
 
 
@@ -61,16 +48,5 @@ class Domain_Contacts_Set_Test extends Test\Lib\Domain_Services_Client_Test_Case
 		$this->assertInstanceOf( Response\Domain\Contacts\Set::class, $response_object );
 
 		$this->assertIsValidResponse( $mock_response_data, $response_object );
-
-		$owner_contact = $response_object->get_contacts()->get_owner();
-		$owner_contact_id = (string) $owner_contact->get_contact_id();
-		$owner_contact_info = $owner_contact->get_contact_information()->to_array();
-		$owner_contact_disclosure = $owner_contact->get_contact_disclosure()->get_disclose_fields();
-
-		$this->assertSame( $mock_response_data['data']['contacts']['owner']['contact_id'], $owner_contact_id );
-		$this->assertSame( $mock_response_data['data']['contacts']['owner']['contact_information'], $owner_contact_info );
-		$this->assertSame( $mock_response_data['data']['contacts']['owner']['contact_disclosure'], $owner_contact_disclosure );
-
-		$this->assertSame( $mock_response_data['data']['contacts'], $response_object->get_contacts()->to_array() );
 	}
 }


### PR DESCRIPTION
Since Domain_Contacts_Set is an asynchronous command, the contact data will be returned in an event instead of in the response object.

Run the unit tests:
```
composer install
./vendor/bin/phpunit -c ./test/phpunit.xml
```