### PR TITLE
Add error trait to Domain_Delete_Fail event and unit test

### DIFF
--- a/lib/event/domain/delete/fail.php
+++ b/lib/event/domain/delete/fail.php
@@ -5,5 +5,5 @@ namespace Automattic\Domain_Services\Event\Domain\Delete;
 use Automattic\Domain_Services\{Event};
 
 class Fail implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+	use Event\Data_Trait, Event\Object_Type_Domain_Trait, Event\Error_Trait;
 }

--- a/test/event/domain-delete-fail-test.php
+++ b/test/event/domain-delete-fail-test.php
@@ -26,6 +26,7 @@ class Domain_Delete_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case 
 					'event_date' => '2022-01-23 12:34:56',
 					'acknowledged_date' => null,
 					'event_data' => [
+						// TODO: Provide accurate error data once this is finalized in the server repo
 						'error' => [
 							'class' => '',
 							'subclass' => 'Domain_Services',
@@ -49,5 +50,6 @@ class Domain_Delete_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case 
 
 		$this->assertInstanceOf( Event\Domain\Delete\Fail::class, $event );
 		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['reason'], $event->get_error_reason() );
 	}
 }


### PR DESCRIPTION
This PR adds the  Event\Error_Trait to the Domain_Delete_Fail event and updates the unit test as well.