### PR TITLE
Add unit test for the Domain_Notification_Agp event

### DIFF
--- a/lib/event/domain/notification/agp.php
+++ b/lib/event/domain/notification/agp.php
@@ -2,8 +2,18 @@
 
 namespace Automattic\Domain_Services\Event\Domain\Notification;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services\{Entity, Event};
 
 class Agp implements Event\Event_Interface {
 	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+
+	public function get_agp_end_date(): ?\DateTimeImmutable {
+		$agp_end_date = $this->get_data_by_key( 'event_data.agp_end_date' ) ?? null;
+
+		if ( null === $agp_end_date ) {
+			return null;
+		}
+
+		return \DateTimeImmutable::createFromFormat( Entity\Entity_Interface::DATE_FORMAT, $agp_end_date );
+	}
 }

--- a/test/event/domain-notification-agp-test.php
+++ b/test/event/domain-notification-agp-test.php
@@ -1,0 +1,47 @@
+<?php declare( strict_types=1 );
+
+namespace Automattic\Domain_Services\Test\Event;
+
+use Automattic\Domain_Services\{Command, Entity, Event, Response, Test};
+
+class Domain_Notification_Agp_Test extends Test\Lib\Domain_Services_Client_Test_Case {
+	public function test_event_success(): void {
+		$command = new Command\Event\Details( 1234 );
+
+		$response_data = [
+			'status' => 200,
+			'status_description' => 'Command completed successfully',
+			'success' => true,
+			'client_txn_id' => 'test-client-transaction-id',
+			'server_txn_id' => '5ffdba44-eeec-4647-9cc4-27cdf8352efc.local-isolated-test-request',
+			'timestamp' => 1669075517,
+			'runtime' => 0.0019,
+			'data' => [
+				'event' => [
+					'id' => 1234,
+					'event_class' => 'Domain_Notification',
+					'event_subclass' => 'Agp',
+					'object_type' => 'domain',
+					'object_id' => 'example.com',
+					'event_date' => '2022-01-23 12:34:56',
+					'acknowledged_date' => null,
+					'event_data' => [
+						'agp_end_date' => '2022-01-28 23:45:01',
+					],
+				],
+			],
+		];
+
+		/** @var Response\Event\Details $response_object */
+		$response_object = $this->response_factory->build_response( $command, $response_data );
+
+		$this->assertIsValidResponse( $response_data, $response_object );
+
+		$event = $response_object->get_event();
+		$this->assertNotNull( $event );
+
+		$this->assertInstanceOf( Event\Domain\Notification\Agp::class, $event );
+		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+		$this->assertSame( $response_data['data']['event']['event_data']['agp_end_date'], $event->get_agp_end_date()->format( Entity\Entity_Interface::DATE_FORMAT ) );
+	}
+}


### PR DESCRIPTION
This PR adds the agp_end_date access method to the Domain_Notification_Agp event and provides a unit test.

Run the unit tests:
```
composer install
./vendor/bin/phpunit -c ./test/phpunit.xml
```