### PR TITLE
Add nameserver event data for the Domain_Nameserver_Set_Success event

### DIFF
--- a/lib/event/domain/nameservers/set/success.php
+++ b/lib/event/domain/nameservers/set/success.php
@@ -2,8 +2,29 @@
 
 namespace Automattic\Domain_Services\Event\Domain\Nameservers\Set;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services\{Entity, Event, Exception};
 
 class Success implements Event\Event_Interface {
 	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+
+	/**
+	 * Returns the name servers that have been set at the registry.
+	 *
+	 * @return Entity\Nameservers
+	 * @throws Exception\Entity\Invalid_Value_Exception
+	 */
+	public function get_nameservers(): ?Entity\Nameservers {
+		$nameservers_data = $this->get_data_by_key( 'event_data.name_servers' );
+
+		if ( null === $nameservers_data ) {
+			return null;
+		}
+
+		$domain_names = [];
+		foreach ( $nameservers_data as $domain ) {
+			$domain_names[] = new Entity\Domain_Name( $domain );
+		}
+
+		return new Entity\Nameservers( ... $domain_names );
+	}
 }

--- a/test/event/domain-nameservers-set-success-test.php
+++ b/test/event/domain-nameservers-set-success-test.php
@@ -19,13 +19,18 @@ class Domain_Nameservers_Set_Success_Test extends Test\Lib\Domain_Services_Clien
 			'data' => [
 				'event' => [
 					'id' => 1234,
-					'event_class' => 'Domain_Delete',
+					'event_class' => 'Domain_Nameservers_Set',
 					'event_subclass' => 'Success',
 					'object_type' => 'domain',
 					'object_id' => 'example.com',
 					'event_date' => '2022-01-23 12:34:56',
 					'acknowledged_date' => null,
-					'event_data' => [],
+					'event_data' => [
+						'name_servers' => [
+							'ns1.wordpress.com',
+							'ns2.wordpress.com',
+						],
+					],
 				],
 			],
 		];
@@ -38,7 +43,8 @@ class Domain_Nameservers_Set_Success_Test extends Test\Lib\Domain_Services_Clien
 		$event = $response_object->get_event();
 		$this->assertNotNull( $event );
 
-		$this->assertInstanceOf( Event\Domain\Delete\Success::class, $event );
+		$this->assertInstanceOf( Event\Domain\Nameservers\Set\Success::class, $event );
 		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+		$this->assertSame( $response_data['data']['event']['event_data']['name_servers'], $event->get_nameservers()->to_array() );
 	}
 }


### PR DESCRIPTION
The server may include the name servers that were set when this event is queued, so we can extract this information in the client event.

Also includes fixes to the unit test where the incorrect event type was used.

Run the unit tests:
```
composer install
./vendor/bin/phpunit -c ./test/phpunit.xml
```