### PR TITLE
Add data access methods and unit tests for the Domain_Register_Success event

### DIFF
--- a/lib/event/domain/register/success.php
+++ b/lib/event/domain/register/success.php
@@ -2,8 +2,37 @@
 
 namespace Automattic\Domain_Services\Event\Domain\Register;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services\{Entity, Event};
 
 class Success implements Event\Event_Interface {
 	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+
+	public function get_domain_status(): ?string {
+		return $this->get_data_by_key( 'event_data.domain_status' );
+	}
+
+	public function get_created_date(): ?\DateTimeInterface {
+		$created_date = $this->get_data_by_key( 'event_data.created_date' );
+		return null === $created_date ? null : \DateTimeImmutable::createFromFormat( Entity\Entity_Interface::DATE_FORMAT, $created_date );
+	}
+
+	public function get_expiration_date(): ?\DateTimeInterface {
+		$expiration_date = $this->get_data_by_key( 'event_data.expiration_date' );
+		return null === $expiration_date ? null : \DateTimeImmutable::createFromFormat( Entity\Entity_Interface::DATE_FORMAT, $expiration_date );
+	}
+
+	public function get_renewal_date(): ?\DateTimeInterface {
+		$renewal_date = $this->get_data_by_key( 'event_data.renewal_date' );
+		return null === $renewal_date ? null : \DateTimeImmutable::createFromFormat( Entity\Entity_Interface::DATE_FORMAT, $renewal_date );
+	}
+
+	public function get_unverified_contact_suspension_date(): ?\DateTimeInterface {
+		$unverified_contact_suspension_date = $this->get_data_by_key( 'event_data.unverified_contact_suspension_date' );
+		return null === $unverified_contact_suspension_date ? null : \DateTimeImmutable::createFromFormat( Entity\Entity_Interface::DATE_FORMAT, $unverified_contact_suspension_date );
+	}
+
+	public function get_contacts(): ?Entity\Domain_Contacts {
+		$contact_data = $this->get_data_by_key( 'event_data.contacts' ) ?? [];
+		return null === $contact_data ? null : Entity\Domain_Contacts::from_array( $contact_data );
+	}
 }

--- a/test/event/domain-register-success-test.php
+++ b/test/event/domain-register-success-test.php
@@ -1,0 +1,106 @@
+<?php declare( strict_types=1 );
+
+namespace Automattic\Domain_Services\Test\Event;
+
+use Automattic\Domain_Services\{Command, Entity, Event, Response, Test};
+
+class Domain_Register_Success_Test extends Test\Lib\Domain_Services_Client_Test_Case {
+	public function test_event_success(): void {
+		$command = new Command\Event\Details( 1234 );
+
+		$contact_info = [
+			'first_name' => 'John',
+			'last_name' => 'Doe',
+			'organization' => '',
+			'address_1' => '60 29th Street #343',
+			'address_2' => '',
+			'postal_code' => '94110',
+			'city' => 'San Francisco',
+			'state' => 'CA',
+			'country_code' => 'US',
+			'email' => 'registrar@automattic.com',
+			'phone' => '+1.8772733049',
+			'fax' => null,
+		];
+
+		$response_data = [
+			'status' => 200,
+			'status_description' => 'Command completed successfully',
+			'success' => true,
+			'client_txn_id' => 'test-client-transaction-id',
+			'server_txn_id' => '5ffdba44-eeec-4647-9cc4-27cdf8352efc.local-isolated-test-request',
+			'timestamp' => 1669075517,
+			'runtime' => 0.0019,
+			'data' => [
+				'event' => [
+					'id' => 1234,
+					'event_class' => 'Domain_Register',
+					'event_subclass' => 'Success',
+					'object_type' => 'domain',
+					'object_id' => 'example.com',
+					'event_date' => '2022-01-23 12:34:56',
+					'acknowledged_date' => null,
+					'event_data' => [
+						'domain_status' => 'ACTIVE',
+						'created_date' => '2022-06-24 15:18:08',
+						'expiration_date' => '2023-06-24 15:18:08',
+						'renewal_date' => '2023-07-29 15:18:08',
+						'unverified_contact_suspension_date' => '2022-07-09 15:18:08',
+						'contacts' => [
+							'owner' => [
+								'contact_id' => 'SP1:P-ABC1234',
+								'contact_information' => $contact_info,
+								'contact_disclosure' => 'none',
+							],
+							'admin' => [
+								'contact_id' => 'SP1:P-ABC1234',
+								'contact_information' => $contact_info,
+								'contact_disclosure' => 'none',
+							],
+							'tech' => [
+								'contact_id' => 'SP1:P-ABC1234',
+								'contact_information' => $contact_info,
+								'contact_disclosure' => 'none',
+							],
+							'billing' => [
+								'contact_id' => 'SP1:P-ABC1234',
+								'contact_information' => $contact_info,
+								'contact_disclosure' => 'none',
+							],
+						],
+					],
+				],
+			],
+		];
+
+		/** @var Response\Event\Details $response_object */
+		$response_object = $this->response_factory->build_response( $command, $response_data );
+
+		$this->assertIsValidResponse( $response_data, $response_object );
+
+		$event = $response_object->get_event();
+		$this->assertNotNull( $event );
+
+		$this->assertInstanceOf( Event\Domain\Register\Success::class, $event );
+		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+
+		$event_contacts = $event->get_contacts();
+		foreach ( $event_contacts as $contact_type => $event_contact ) {
+			$contact_id = (string) $event_contact->get_contact_id();
+			$contact_info = $event_contact->get_contact_information()->to_array();
+			$contact_disclosure = $event_contact->get_contact_disclosure()->get_disclose_fields();
+
+			$this->assertSame( $response_data['data']['event']['event_data']['contacts'][ $contact_type ]['contact_id'], $contact_id );
+			$this->assertSame( $response_data['data']['event']['event_data']['contacts'][ $contact_type ]['contact_information'], $contact_info );
+			$this->assertSame( $response_data['data']['event']['event_data']['contacts'][ $contact_type ]['contact_disclosure'], $contact_disclosure );
+		}
+
+		$this->assertSame( $response_data['data']['event']['event_data']['contacts'], $event->get_contacts()->to_array() );
+
+		$this->assertSame( $response_data['data']['event']['event_data']['domain_status'], $event->get_domain_status() );
+		$this->assertSame( $response_data['data']['event']['event_data']['created_date'], $event->get_created_date()->format( Entity\Entity_Interface::DATE_FORMAT ) );
+		$this->assertSame( $response_data['data']['event']['event_data']['expiration_date'], $event->get_expiration_date()->format( Entity\Entity_Interface::DATE_FORMAT ) );
+		$this->assertSame( $response_data['data']['event']['event_data']['renewal_date'], $event->get_renewal_date()->format( Entity\Entity_Interface::DATE_FORMAT ) );
+		$this->assertSame( $response_data['data']['event']['event_data']['unverified_contact_suspension_date'], $event->get_unverified_contact_suspension_date()->format( Entity\Entity_Interface::DATE_FORMAT ) );
+	}
+}


### PR DESCRIPTION
This PR adds data access methods for all of the event data and a unit test for the Domain_Register_Success event.

Run the unit tests:
```
composer install
./vendor/bin/phpunit -c ./test/phpunit.xml
```