### PR TITLE
Remove domain registration detail data from the register response

### DIFF
--- a/lib/response/domain/register.php
+++ b/lib/response/domain/register.php
@@ -2,37 +2,8 @@
 
 namespace Automattic\Domain_Services\Response\Domain;
 
-use Automattic\Domain_Services\{Entity, Response};
+use Automattic\Domain_Services\{Response};
 
 class Register implements Response\Response_Interface {
 	use Response\Data_Trait;
-
-	public function get_domain_status(): ?string {
-		return $this->get_data_by_key( 'data.domain_status' );
-	}
-
-	public function get_created_date(): ?\DateTimeInterface {
-		$created_date = $this->get_data_by_key( 'data.created_date' );
-		return null === $created_date ? null : \DateTimeImmutable::createFromFormat( Entity\Entity_Interface::DATE_FORMAT, $created_date );
-	}
-
-	public function get_expiration_date(): ?\DateTimeInterface {
-		$expiration_date = $this->get_data_by_key( 'data.expiration_date' );
-		return null === $expiration_date ? null : \DateTimeImmutable::createFromFormat( Entity\Entity_Interface::DATE_FORMAT, $expiration_date );
-	}
-
-	public function get_renewal_date(): ?\DateTimeInterface {
-		$renewal_date = $this->get_data_by_key( 'data.renewal_date' );
-		return null === $renewal_date ? null : \DateTimeImmutable::createFromFormat( Entity\Entity_Interface::DATE_FORMAT, $renewal_date );
-	}
-
-	public function get_unverified_contact_suspension_date(): ?\DateTimeInterface {
-		$unverified_contact_suspension_date = $this->get_data_by_key( 'data.unverified_contact_suspension_date' );
-		return null === $unverified_contact_suspension_date ? null : \DateTimeImmutable::createFromFormat( Entity\Entity_Interface::DATE_FORMAT, $unverified_contact_suspension_date );
-	}
-
-	public function get_contacts(): Entity\Domain_Contacts {
-		$contact_data = $this->get_data_by_key( 'data.contacts' ) ?? [];
-		return Entity\Domain_Contacts::from_array( $contact_data );
-	}
 }

--- a/test/response/domain-register-test.php
+++ b/test/response/domain-register-test.php
@@ -59,35 +59,7 @@ class Domain_Register_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 			'server_txn_id' => '990c3ae1-3210-49f2-9ce6-51a14bc2a2c6.local-isolated-test-request',
 			'timestamp' => 1669075523,
 			'runtime' => 0.0029,
-			'data' => [
-				'domain_status' => 'ACTIVE',
-				'created_date' => '2022-06-24 15:18:08',
-				'expiration_date' => '2023-06-24 15:18:08',
-				'renewal_date' => '2023-07-29 15:18:08',
-				'unverified_contact_suspension_date' => '2022-07-09 15:18:08',
-				'contacts' => [
-					'owner' => [
-						'contact_id' => 'SP1:P-ABC1234',
-						'contact_information' => $contact_info,
-						'contact_disclosure' => 'none',
-					],
-					'admin' => [
-						'contact_id' => 'SP1:P-ABC1234',
-						'contact_information' => $contact_info,
-						'contact_disclosure' => 'none',
-					],
-					'tech' => [
-						'contact_id' => 'SP1:P-ABC1234',
-						'contact_information' => $contact_info,
-						'contact_disclosure' => 'none',
-					],
-					'billing' => [
-						'contact_id' => 'SP1:P-ABC1234',
-						'contact_information' => $contact_info,
-						'contact_disclosure' => 'none',
-					],
-				],
-			],
+			'data' => [],
 		];
 
 		/** @var Response\Domain\Register $response_object */
@@ -96,24 +68,5 @@ class Domain_Register_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 		$this->assertInstanceOf( Response\Domain\Register::class, $response_object );
 
 		$this->assertIsValidResponse( $mock_response_data, $response_object );
-
-		$response_contacts = $response_object->get_contacts();
-		foreach ( $response_contacts as $contact_type => $response_contact ) {
-			$contact_id = (string) $response_contact->get_contact_id();
-			$contact_info = $response_contact->get_contact_information()->to_array();
-			$contact_disclosure = $response_contact->get_contact_disclosure()->get_disclose_fields();
-
-			$this->assertSame( $mock_response_data['data']['contacts'][ $contact_type ]['contact_id'], $contact_id );
-			$this->assertSame( $mock_response_data['data']['contacts'][ $contact_type ]['contact_information'], $contact_info );
-			$this->assertSame( $mock_response_data['data']['contacts'][ $contact_type ]['contact_disclosure'], $contact_disclosure );
-		}
-
-		$this->assertSame( $mock_response_data['data']['contacts'], $response_object->get_contacts()->to_array() );
-
-		$this->assertSame( $mock_response_data['data']['domain_status'], $response_object->get_domain_status() );
-		$this->assertSame( $mock_response_data['data']['created_date'], $response_object->get_created_date()->format( Entity\Entity_Interface::DATE_FORMAT ) );
-		$this->assertSame( $mock_response_data['data']['expiration_date'], $response_object->get_expiration_date()->format( Entity\Entity_Interface::DATE_FORMAT ) );
-		$this->assertSame( $mock_response_data['data']['renewal_date'], $response_object->get_renewal_date()->format( Entity\Entity_Interface::DATE_FORMAT ) );
-		$this->assertSame( $mock_response_data['data']['unverified_contact_suspension_date'], $response_object->get_unverified_contact_suspension_date()->format( Entity\Entity_Interface::DATE_FORMAT ) );
 	}
 }


### PR DESCRIPTION
Since the Domain_Register command will be asynchronous, the domain detail data will be returned in the Domain_Register_Success event instead of in the Domain_Register response.

This PR removes the data access methods from the response class and updates the unit test.

Run the unit tests:
```
composer install
./vendor/bin/phpunit -c ./test/phpunit.xml
```