### PR TITLE
Remove unused response from the Domain_Contacts_Set response class

### DIFF
--- a/lib/response/domain/contacts/set.php
+++ b/lib/response/domain/contacts/set.php
@@ -2,7 +2,7 @@
 
 namespace Automattic\Domain_Services\Response\Domain\Contacts;
 
-use Automattic\Domain_Services\{Entity, Response};
+use Automattic\Domain_Services\{Response};
 
 class Set implements Response\Response_Interface {
 	use Response\Data_Trait;


### PR DESCRIPTION
This PR just removed an import from the Domain_Contacts_Set response that is no longer used.

Run the unit tests:
```
composer install
./vendor/bin/phpunit -c ./test/phpunit.xml
```