### PR TITLE
Add unit test and data access methods for the Domain_Renew_Success event

### DIFF
--- a/lib/event/domain/renew/success.php
+++ b/lib/event/domain/renew/success.php
@@ -2,8 +2,22 @@
 
 namespace Automattic\Domain_Services\Event\Domain\Renew;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services\{Entity, Event};
 
 class Success implements Event\Event_Interface {
 	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+
+	public function get_domain_status(): ?string {
+		return $this->get_data_by_key( 'event_data.domain_status' );
+	}
+
+	public function get_expiration_date(): ?\DateTimeInterface {
+		$expiration_date = $this->get_data_by_key( 'event_data.expiration_date' );
+		return null === $expiration_date ? null : \DateTimeImmutable::createFromFormat( Entity\Entity_Interface::DATE_FORMAT, $expiration_date );
+	}
+
+	public function get_renewal_date(): ?\DateTimeInterface {
+		$renewal_date = $this->get_data_by_key( 'event_data.renewal_date' );
+		return null === $renewal_date ? null : \DateTimeImmutable::createFromFormat( Entity\Entity_Interface::DATE_FORMAT, $renewal_date );
+	}
 }

--- a/test/event/domain-renew-success-test.php
+++ b/test/event/domain-renew-success-test.php
@@ -1,0 +1,52 @@
+<?php declare( strict_types=1 );
+
+namespace Automattic\Domain_Services\Test\Event;
+
+use Automattic\Domain_Services\{Command, Entity, Event, Response, Test};
+
+class Domain_Renew_Success_Test extends Test\Lib\Domain_Services_Client_Test_Case {
+	public function test_event_success(): void {
+		$command = new Command\Event\Details( 1234 );
+
+		$response_data = [
+			'status' => 200,
+			'status_description' => 'Command completed successfully',
+			'success' => true,
+			'client_txn_id' => 'test-client-transaction-id',
+			'server_txn_id' => '5ffdba44-eeec-4647-9cc4-27cdf8352efc.local-isolated-test-request',
+			'timestamp' => 1669075517,
+			'runtime' => 0.0019,
+			'data' => [
+				'event' => [
+					'id' => 1234,
+					'event_class' => 'Domain_Renew',
+					'event_subclass' => 'Success',
+					'object_type' => 'domain',
+					'object_id' => 'example.com',
+					'event_date' => '2022-01-23 12:34:56',
+					'acknowledged_date' => null,
+					'event_data' => [
+						'domain_status' => 'ACTIVE',
+						'expiration_date' => '2023-06-24 15:18:08',
+						'renewal_date' => '2023-07-29 15:18:08',
+					],
+				],
+			],
+		];
+
+		/** @var Response\Event\Details $response_object */
+		$response_object = $this->response_factory->build_response( $command, $response_data );
+
+		$this->assertIsValidResponse( $response_data, $response_object );
+
+		$event = $response_object->get_event();
+		$this->assertNotNull( $event );
+
+		$this->assertInstanceOf( Event\Domain\Renew\Success::class, $event );
+		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+
+		$this->assertSame( $response_data['data']['event']['event_data']['domain_status'], $event->get_domain_status() );
+		$this->assertSame( $response_data['data']['event']['event_data']['expiration_date'], $event->get_expiration_date()->format( Entity\Entity_Interface::DATE_FORMAT ) );
+		$this->assertSame( $response_data['data']['event']['event_data']['renewal_date'], $event->get_renewal_date()->format( Entity\Entity_Interface::DATE_FORMAT ) );
+	}
+}


### PR DESCRIPTION
This PR adds data access methods and a unit test for the Domain_Renew_Success event.

Run the unit tests:
```
composer install
./vendor/bin/phpunit -c ./test/phpunit.xml
```