### PR TITLE
Remove the response data from the Domain_Renew response

### DIFF
--- a/lib/response/domain/renew.php
+++ b/lib/response/domain/renew.php
@@ -6,9 +6,4 @@ use Automattic\Domain_Services\{Entity, Response};
 
 class Renew implements Response\Response_Interface {
 	use Response\Data_Trait;
-
-	public function get_expiration_date(): ?\DateTimeImmutable {
-		$expiration_date = $this->get_data_by_key( 'data.expiration_date' );
-		return null === $expiration_date ? null : \DateTimeImmutable::createFromFormat( Entity\Entity_Interface::DATE_FORMAT, $expiration_date );
-	}
 }

--- a/test/response/domain-renew-test.php
+++ b/test/response/domain-renew-test.php
@@ -10,9 +10,7 @@ class Domain_Renew_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 		$command = new Command\Domain\Renew( $domain_name, 2022, 1, null );
 
 		$response_data = [
-			'data' => [
-				'expiration_date' => '2024-06-30 12:00:00',
-			],
+			'data' => [],
 			'status' => 200,
 			'status_description' => 'Command completed successfully',
 			'success' => true,
@@ -28,7 +26,5 @@ class Domain_Renew_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 		$this->assertInstanceOf( Response\Domain\Renew::class, $response_object );
 
 		$this->assertIsValidResponse( $response_data, $response_object );
-
-		$this->assertSame( $response_data['data']['expiration_date'], $response_object->get_expiration_date()->format( Entity\Entity_Interface::DATE_FORMAT ) );
 	}
 }


### PR DESCRIPTION
Since the Domain _Renew command will be handled asynchronously, we will return the new domain data in the event rather than in the response for this command.

This PR removes the data access method from the response class and updates the corresponding unit test.

Run the unit tests:
```
composer install
./vendor/bin/phpunit -c ./test/phpunit.xml
```