### PR TITLE
Add unit tests for the Domain_Transferlock_Set events

### DIFF
--- a/lib/event/domain/transferlock/set/fail.php
+++ b/lib/event/domain/transferlock/set/fail.php
@@ -1,6 +1,6 @@
 <?php declare( strict_types=1 );
 
-namespace Automattic\Domain_Services\Event\Domain\Contacts\Set;
+namespace Automattic\Domain_Services\Event\Domain\Transferlock\Set;
 
 use Automattic\Domain_Services\{Event};
 

--- a/lib/event/domain/transferlock/set/success.php
+++ b/lib/event/domain/transferlock/set/success.php
@@ -1,9 +1,13 @@
 <?php declare( strict_types=1 );
 
-namespace Automattic\Domain_Services\Event\Domain\Contacts\Set;
+namespace Automattic\Domain_Services\Event\Domain\Transferlock\Set;
 
 use Automattic\Domain_Services\{Event};
 
 class Success implements Event\Event_Interface {
 	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+
+	public function is_locked(): bool {
+		return $this->get_data_by_key( 'event_data.transferlock' ) ?? false;
+	}
 }


### PR DESCRIPTION
This PR adds unit tests for the Domain_Transferlock_Set_Success and Domain_Transferlock_Set_Fail events.
It also fixes a bug where these event classes used the incorrect namespace and adds a data access method for the success event to tell the current state of the transferlock when the event is generated.

Run the unit tests:
```
composer install
./vendor/bin/phpunit -c ./test/phpunit.xml
```