### PR TITLE
Update the Command\Events\Get doc blocks

### DIFF
--- a/lib/command/events/get.php
+++ b/lib/command/events/get.php
@@ -21,9 +21,14 @@ namespace Automattic\Domain_Services\Command\Events;
 use Automattic\Domain_Services\{Command};
 
 /**
- * This command is used to get a list of the unacknowledged events. On success, the response object will include an
+ * Requests a list of unacknowledged events
+ *
+ * This command is used to request a list of the unacknowledged events. On success, the response object will include an
  * array of events in ascending order by age (oldest to newest). The maximum number of events returned in the response,
  * can be set using the $limit property for this command. The limit defaults to 50 if none is set.
+ *
+ * This command executes synchronously on the server. The corresponding response object will include the list of events.
+ * @see \Automattic\Domain_Services\Response\Events\Get
  */
 class Get implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Trait, Command\Command_Serialize_Trait, Command\Array_Key_Event_Trait;


### PR DESCRIPTION
This PR adds detail about the `Events\Get` command. (No logic changes.)