### PR TITLE
Update format to use one trait per line and reduce comment line length.

### DIFF
--- a/lib/command/contact/details.php
+++ b/lib/command/contact/details.php
@@ -24,7 +24,9 @@ use Automattic\Domain_Services\{Command, Entity};
  * Retrieves the details of a Contact_Id.
  */
 class Details implements Command\Command_Interface, Command\Command_Serialize_Interface {
-	use Command\Command_Trait, Command\Command_Serialize_Trait, Command\Array_Key_Contact_Id_Trait;
+	use Command\Array_Key_Contact_Id_Trait;
+	use Command\Command_Serialize_Trait;
+	use Command\Command_Trait;
 
 	/**
 	 * The contact ID to get details of.

--- a/lib/command/dns/records/get.php
+++ b/lib/command/dns/records/get.php
@@ -24,7 +24,9 @@ use Automattic\Domain_Services\{Command, Entity};
  * Retrieves all DNS records associated with a domain.
  */
 class Get implements Command\Command_Interface, Command\Command_Serialize_Interface {
-	use Command\Command_Trait, Command\Command_Serialize_Trait, Command\Array_Key_Domain_Trait;
+	use Command\Array_Key_Domain_Trait;
+	use Command\Command_Serialize_Trait;
+	use Command\Command_Trait;
 
 	private Entity\Domain_Name $domain;
 

--- a/lib/command/dns/records/set.php
+++ b/lib/command/dns/records/set.php
@@ -24,7 +24,9 @@ use Automattic\Domain_Services\{Command, Entity};
  * Updates all DNS records associated with a domain.
  */
 class Set implements Command\Command_Interface, Command\Command_Serialize_Interface {
-	use Command\Command_Trait, Command\Command_Serialize_Trait, Command\Array_Key_Dns_Records_Trait;
+	use Command\Array_Key_Dns_Records_Trait;
+	use Command\Command_Serialize_Trait;
+	use Command\Command_Trait;
 
 	private Entity\Dns_Records $records;
 

--- a/lib/command/domain/check.php
+++ b/lib/command/domain/check.php
@@ -21,7 +21,9 @@ namespace Automattic\Domain_Services\Command\Domain;
 use Automattic\Domain_Services\{Command, Entity, Exception};
 
 class Check implements Command\Command_Interface, Command\Command_Serialize_Interface {
-	use Command\Command_Trait, Command\Command_Serialize_Trait, Command\Array_Key_Domains_Trait;
+	use Command\Array_Key_Domains_Trait;
+	use Command\Command_Serialize_Trait;
+	use Command\Command_Trait;
 
 	/**
 	 * List of domains to check for availability.

--- a/lib/command/domain/contacts/set.php
+++ b/lib/command/domain/contacts/set.php
@@ -21,7 +21,10 @@ namespace Automattic\Domain_Services\Command\Domain\Contacts;
 use Automattic\Domain_Services\{Command, Entity, Exception};
 
 class Set implements Command\Command_Interface, Command\Command_Serialize_Interface {
-	use Command\Command_Trait, Command\Command_Serialize_Trait, Command\Array_Key_Contacts_Trait, Command\Array_Key_Domain_Trait;
+	use Command\Array_Key_Contacts_Trait;
+	use Command\Array_Key_Domain_Trait;
+	use Command\Command_Serialize_Trait;
+	use Command\Command_Trait;
 
 	/**
 	 * The domain name that will be updated.

--- a/lib/command/domain/delete.php
+++ b/lib/command/domain/delete.php
@@ -21,7 +21,9 @@ namespace Automattic\Domain_Services\Command\Domain;
 use Automattic\Domain_Services\{Command, Entity};
 
 class Delete implements Command\Command_Interface, Command\Command_Serialize_Interface {
-	use Command\Command_Trait, Command\Command_Serialize_Trait, Command\Array_Key_Domain_Trait;
+	use Command\Array_Key_Domain_Trait;
+	use Command\Command_Serialize_Trait;
+	use Command\Command_Trait;
 
 	/**
 	 * The domain name to delete

--- a/lib/command/domain/info.php
+++ b/lib/command/domain/info.php
@@ -23,12 +23,14 @@ use Automattic\Domain_Services\{Command, Entity};
 /**
  * Retrieves information about a domain that is registered with us.
  *
- * Retrieves various information about a domain that is registered with us, such as creation and expiry dates, auth code,
- * name servers and EPP statuses. If the domain is not registered with us, the information of a Domain_Check command
- * is returned instead (domain availability and fees).
+ * Retrieves various information about a domain that is registered with us, such as creation and expiry dates, auth
+ * code, name servers and EPP statuses. If the domain is not registered with us, the information of a Domain_Check
+ * command is returned instead (domain availability and fees).
  */
 class Info implements Command\Command_Interface, Command\Command_Serialize_Interface {
-	use Command\Command_Trait, Command\Command_Serialize_Trait, Command\Array_Key_Domain_Trait;
+	use Command\Array_Key_Domain_Trait;
+	use Command\Command_Serialize_Trait;
+	use Command\Command_Trait;
 
 	/**
 	 * @var Entity\Domain_Name domain which information will be retrieved

--- a/lib/command/domain/nameservers/set.php
+++ b/lib/command/domain/nameservers/set.php
@@ -24,7 +24,10 @@ use Automattic\Domain_Services\{Command, Entity};
  * Set the nameservers for the specified domain
  */
 class Set implements Command\Command_Interface, Command\Command_Serialize_Interface {
-	use Command\Command_Trait, Command\Command_Serialize_Trait, Command\Array_Key_Domain_Trait, Command\Array_Key_Nameservers_Trait;
+	use Command\Array_Key_Domain_Trait;
+	use Command\Array_Key_Nameservers_Trait;
+	use Command\Command_Serialize_Trait;
+	use Command\Command_Trait;
 
 	/**
 	 * The domain name that will be updated.

--- a/lib/command/domain/privacy/set.php
+++ b/lib/command/domain/privacy/set.php
@@ -21,10 +21,14 @@ namespace Automattic\Domain_Services\Command\Domain\Privacy;
 use Automattic\Domain_Services\{Command, Entity};
 
 /**
- * Sets the privacy option that determines what contact information is shown in the response of a whois query for this domain.
+ * Sets the privacy option that determines what contact information is shown in the response of a whois query for this
+ * domain.
  */
 class Set implements Command\Command_Interface, Command\Command_Serialize_Interface {
-	use Command\Command_Trait, Command\Command_Serialize_Trait, Command\Array_Key_Domain_Trait, Command\Array_Key_Privacy_Setting_Trait;
+	use Command\Array_Key_Domain_Trait;
+	use Command\Array_Key_Privacy_Setting_Trait;
+	use Command\Command_Serialize_Trait;
+	use Command\Command_Trait;
 
 	/**
 	 * The domain that will be updated.

--- a/lib/command/domain/register.php
+++ b/lib/command/domain/register.php
@@ -21,7 +21,10 @@ namespace Automattic\Domain_Services\Command\Domain;
 use Automattic\Domain_Services\{Command, Entity, Exception};
 
 class Register implements Command\Command_Interface, Command\Command_Serialize_Interface {
-	use Command\Command_Trait, Command\Command_Serialize_Trait, Command\Array_Key_Domain_Trait, Command\Array_Key_Contacts_Trait;
+	use Command\Array_Key_Contacts_Trait;
+	use Command\Array_Key_Domain_Trait;
+	use Command\Command_Serialize_Trait;
+	use Command\Command_Trait;
 
 	/**
 	 * The domain name to register

--- a/lib/command/domain/renew.php
+++ b/lib/command/domain/renew.php
@@ -21,7 +21,12 @@ namespace Automattic\Domain_Services\Command\Domain;
 use Automattic\Domain_Services\{Command, Entity};
 
 class Renew implements Command\Command_Interface, Command\Command_Serialize_Interface {
-	use Command\Command_Trait, Command\Command_Serialize_Trait, Command\Array_Key_Domain_Trait, Command\Array_Key_Period_Trait, Command\Array_Key_Current_Expiration_Year_Trait, Command\Array_Key_Fee_Amount_Trait;
+	use Command\Array_Key_Current_Expiration_Year_Trait;
+	use Command\Array_Key_Domain_Trait;
+	use Command\Array_Key_Fee_Amount_Trait;
+	use Command\Array_Key_Period_Trait;
+	use Command\Command_Serialize_Trait;
+	use Command\Command_Trait;
 
 	/**
 	 * The domain name to renew
@@ -39,8 +44,9 @@ class Renew implements Command\Command_Interface, Command\Command_Serialize_Inte
 	private int $period;
 
 	/**
-	 * The current expiration year of the domain. If the domain is in auto renew grace period (a specified number of calendar
-	 * days following an auto-renewal), please use the previous expiration. This will prevent unintended two year renewals.
+	 * The current expiration year of the domain. If the domain is in auto renew grace period (a specified number of
+	 * calendar days following an auto-renewal), please use the previous expiration. This will prevent unintended two
+	 * year renewals.
 	 *
 	 * @var int
 	 */

--- a/lib/command/domain/restore.php
+++ b/lib/command/domain/restore.php
@@ -26,7 +26,9 @@ use Automattic\Domain_Services\{Command, Entity};
  * @package Automattic\Domain_Services\Command\Domain
  */
 class Restore implements Command\Command_Interface, Command\Command_Serialize_Interface {
-	use Command\Command_Trait, Command\Command_Serialize_Trait, Command\Array_Key_Domain_Trait;
+	use Command\Array_Key_Domain_Trait;
+	use Command\Command_Serialize_Trait;
+	use Command\Command_Trait;
 
 	/**
 	 * @var Entity\Domain_Name domain to be restored

--- a/lib/command/domain/transferlock/set.php
+++ b/lib/command/domain/transferlock/set.php
@@ -21,7 +21,11 @@ namespace Automattic\Domain_Services\Command\Domain\Transferlock;
 use Automattic\Domain_Services\{Command, Entity};
 
 class Set implements Command\Command_Interface, Command\Command_Serialize_Interface {
-	use Command\Command_Trait, Command\Command_Serialize_Trait, Command\Array_Key_Domain_Trait, Command\Array_Key_Domain_Trait, Command\Array_Key_Transferlock_Trait;
+	use Command\Array_Key_Domain_Trait;
+	use Command\Array_Key_Domain_Trait;
+	use Command\Array_Key_Transferlock_Trait;
+	use Command\Command_Serialize_Trait;
+	use Command\Command_Trait;
 
 	/**
 	 * The domain name that will be updated.

--- a/lib/command/event/ack.php
+++ b/lib/command/event/ack.php
@@ -31,7 +31,9 @@ use Automattic\Domain_Services\{Command};
  * @see \Automattic\Domain_Services\Response\Events\Get
  */
 class Ack implements Command\Command_Interface, Command\Command_Serialize_Interface {
-	use Command\Command_Trait, Command\Command_Serialize_Trait, Command\Array_Key_Event_Trait;
+	use Command\Array_Key_Event_Trait;
+	use Command\Command_Serialize_Trait;
+	use Command\Command_Trait;
 
 	/**
 	 * ID of the event to be acknowledged.

--- a/lib/command/events/get.php
+++ b/lib/command/events/get.php
@@ -32,7 +32,9 @@ use Automattic\Domain_Services\{Command};
  * @see \Automattic\Domain_Services\Response\Events\Get
  */
 class Get implements Command\Command_Interface, Command\Command_Serialize_Interface {
-	use Command\Command_Trait, Command\Command_Serialize_Trait, Command\Array_Key_Event_Trait;
+	use Command\Array_Key_Event_Trait;
+	use Command\Command_Serialize_Trait;
+	use Command\Command_Trait;
 
 	/**
 	 * Max count of returned events

--- a/lib/entity/dns-records.php
+++ b/lib/entity/dns-records.php
@@ -21,7 +21,8 @@ namespace Automattic\Domain_Services\Entity;
 use Automattic\Domain_Services\{Command};
 
 class Dns_Records {
-	use Command\Array_Key_Domain_Trait, Command\Array_Key_Dns_Record_Sets_Trait;
+	use Command\Array_Key_Dns_Record_Sets_Trait;
+	use Command\Array_Key_Domain_Trait;
 
 	/**
 	 * The domain name that the DNS records apply to.

--- a/lib/entity/domain-contact.php
+++ b/lib/entity/domain-contact.php
@@ -21,7 +21,9 @@ namespace Automattic\Domain_Services\Entity;
 use Automattic\Domain_Services\{Command};
 
 class Domain_Contact {
-	use Command\Array_Key_Contact_Id_Trait, Command\Array_Key_Contact_Information_Trait, Command\Array_Key_Contact_Disclosure_Trait;
+	use Command\Array_Key_Contact_Disclosure_Trait;
+	use Command\Array_Key_Contact_Id_Trait;
+	use Command\Array_Key_Contact_Information_Trait;
 
 	/**
 	 * The contact ID

--- a/lib/event/contact/verification/notify.php
+++ b/lib/event/contact/verification/notify.php
@@ -24,7 +24,8 @@ use Automattic\Domain_Services\{Event};
  * This event indicates a change in the contact status
  */
 class Notify implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Contact_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Contact_Trait;
 
 	/**
 	 * Returns tha verification status of the contact.

--- a/lib/event/contact/verification/request.php
+++ b/lib/event/contact/verification/request.php
@@ -24,7 +24,8 @@ use Automattic\Domain_Services\{Event};
  * This event indicates that a verification request was sent to the contact's email address.
  */
 class Request implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Contact_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Contact_Trait;
 
 	/**
 	 * Returns the email address that the verification request was sent to.

--- a/lib/event/domain/contacts/set/fail.php
+++ b/lib/event/domain/contacts/set/fail.php
@@ -21,5 +21,7 @@ namespace Automattic\Domain_Services\Event\Domain\Contacts\Set;
 use Automattic\Domain_Services\{Event};
 
 class Fail implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait, Event\Error_Trait;
+	use Event\Data_Trait;
+	use Event\Error_Trait;
+	use Event\Object_Type_Domain_Trait;
 }

--- a/lib/event/domain/contacts/set/success.php
+++ b/lib/event/domain/contacts/set/success.php
@@ -21,7 +21,8 @@ namespace Automattic\Domain_Services\Event\Domain\Contacts\Set;
 use Automattic\Domain_Services\{Entity, Event};
 
 class Success implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Domain_Trait;
 
 	public function get_contacts(): Entity\Domain_Contacts {
 		$contact_data = $this->get_data_by_key( 'event_data.contacts' ) ?? [];

--- a/lib/event/domain/delete/fail.php
+++ b/lib/event/domain/delete/fail.php
@@ -21,5 +21,7 @@ namespace Automattic\Domain_Services\Event\Domain\Delete;
 use Automattic\Domain_Services\{Event};
 
 class Fail implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait, Event\Error_Trait;
+	use Event\Data_Trait;
+	use Event\Error_Trait;
+	use Event\Object_Type_Domain_Trait;
 }

--- a/lib/event/domain/delete/success.php
+++ b/lib/event/domain/delete/success.php
@@ -21,5 +21,6 @@ namespace Automattic\Domain_Services\Event\Domain\Delete;
 use Automattic\Domain_Services\{Event};
 
 class Success implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Domain_Trait;
 }

--- a/lib/event/domain/nameservers/set/fail.php
+++ b/lib/event/domain/nameservers/set/fail.php
@@ -21,5 +21,7 @@ namespace Automattic\Domain_Services\Event\Domain\Nameservers\Set;
 use Automattic\Domain_Services\{Event};
 
 class Fail implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait, Event\Error_Trait;
+	use Event\Data_Trait;
+	use Event\Error_Trait;
+	use Event\Object_Type_Domain_Trait;
 }

--- a/lib/event/domain/nameservers/set/success.php
+++ b/lib/event/domain/nameservers/set/success.php
@@ -21,7 +21,8 @@ namespace Automattic\Domain_Services\Event\Domain\Nameservers\Set;
 use Automattic\Domain_Services\{Entity, Event, Exception};
 
 class Success implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Domain_Trait;
 
 	/**
 	 * Returns the name servers that have been set at the registry.

--- a/lib/event/domain/notification/agp.php
+++ b/lib/event/domain/notification/agp.php
@@ -21,7 +21,8 @@ namespace Automattic\Domain_Services\Event\Domain\Notification;
 use Automattic\Domain_Services\{Entity, Event};
 
 class Agp implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Domain_Trait;
 
 	public function get_agp_end_date(): ?\DateTimeImmutable {
 		$agp_end_date = $this->get_data_by_key( 'event_data.agp_end_date' );

--- a/lib/event/domain/notification/argp.php
+++ b/lib/event/domain/notification/argp.php
@@ -21,7 +21,8 @@ namespace Automattic\Domain_Services\Event\Domain\Notification;
 use Automattic\Domain_Services\{Entity, Event};
 
 class Argp implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Domain_Trait;
 
 	public function get_argp_end_date(): ?\DateTimeImmutable {
 		$argp_end_date = $this->get_data_by_key( 'event_data.argp_end_date' );

--- a/lib/event/domain/notification/auction.php
+++ b/lib/event/domain/notification/auction.php
@@ -21,7 +21,8 @@ namespace Automattic\Domain_Services\Event\Domain\Notification;
 use Automattic\Domain_Services\{Entity, Event};
 
 class Auction implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Domain_Trait;
 
 	/**
 	 * This should be one of PARKED, SUBMITTED, ACTIVE

--- a/lib/event/domain/notification/expired.php
+++ b/lib/event/domain/notification/expired.php
@@ -21,5 +21,6 @@ namespace Automattic\Domain_Services\Event\Domain\Notification;
 use Automattic\Domain_Services\{Event};
 
 class Expired implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Domain_Trait;
 }

--- a/lib/event/domain/notification/redemption.php
+++ b/lib/event/domain/notification/redemption.php
@@ -21,7 +21,8 @@ namespace Automattic\Domain_Services\Event\Domain\Notification;
 use Automattic\Domain_Services\{Entity, Event};
 
 class Redemption implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Domain_Trait;
 
 	public function get_redemption_end_date(): ?\DateTimeImmutable {
 		$redemption_end_date = $this->get_data_by_key( 'event_data.redemption_end_date' );

--- a/lib/event/domain/notification/suspended.php
+++ b/lib/event/domain/notification/suspended.php
@@ -21,7 +21,8 @@ namespace Automattic\Domain_Services\Event\Domain\Notification;
 use Automattic\Domain_Services\{Event};
 
 class Suspended implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Domain_Trait;
 
 	/**
 	 * Returns information about the reason the domain is suspended, if available.

--- a/lib/event/domain/notification/verified.php
+++ b/lib/event/domain/notification/verified.php
@@ -21,7 +21,8 @@ namespace Automattic\Domain_Services\Event\Domain\Notification;
 use Automattic\Domain_Services\{Event};
 
 class Verified implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Domain_Trait;
 
 	/**
 	 * Returns information about the reason the domain is verified, if available.

--- a/lib/event/domain/privacy/set/fail.php
+++ b/lib/event/domain/privacy/set/fail.php
@@ -21,5 +21,7 @@ namespace Automattic\Domain_Services\Event\Domain\Privacy\Set;
 use Automattic\Domain_Services\{Event};
 
 class Fail implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait, Event\Error_Trait;
+	use Event\Data_Trait;
+	use Event\Error_Trait;
+	use Event\Object_Type_Domain_Trait;
 }

--- a/lib/event/domain/privacy/set/success.php
+++ b/lib/event/domain/privacy/set/success.php
@@ -21,7 +21,8 @@ namespace Automattic\Domain_Services\Event\Domain\Privacy\Set;
 use Automattic\Domain_Services\{Entity, Event, Exception};
 
 class Success implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Domain_Trait;
 
 	/**
 	 * Returns the Whois_Privacy setting that for this domain, if available

--- a/lib/event/domain/register/fail.php
+++ b/lib/event/domain/register/fail.php
@@ -21,5 +21,7 @@ namespace Automattic\Domain_Services\Event\Domain\Register;
 use Automattic\Domain_Services\{Event};
 
 class Fail implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait, Event\Error_Trait;
+	use Event\Data_Trait;
+	use Event\Error_Trait;
+	use Event\Object_Type_Domain_Trait;
 }

--- a/lib/event/domain/register/success.php
+++ b/lib/event/domain/register/success.php
@@ -21,7 +21,8 @@ namespace Automattic\Domain_Services\Event\Domain\Register;
 use Automattic\Domain_Services\{Entity, Event};
 
 class Success implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Domain_Trait;
 
 	public function get_domain_status(): ?string {
 		return $this->get_data_by_key( 'event_data.domain_status' );

--- a/lib/event/domain/renew/fail.php
+++ b/lib/event/domain/renew/fail.php
@@ -21,5 +21,7 @@ namespace Automattic\Domain_Services\Event\Domain\Renew;
 use Automattic\Domain_Services\{Event};
 
 class Fail implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait, Event\Error_Trait;
+	use Event\Data_Trait;
+	use Event\Error_Trait;
+	use Event\Object_Type_Domain_Trait;
 }

--- a/lib/event/domain/renew/success.php
+++ b/lib/event/domain/renew/success.php
@@ -21,7 +21,8 @@ namespace Automattic\Domain_Services\Event\Domain\Renew;
 use Automattic\Domain_Services\{Entity, Event};
 
 class Success implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Domain_Trait;
 
 	public function get_domain_status(): ?string {
 		return $this->get_data_by_key( 'event_data.domain_status' );

--- a/lib/event/domain/restore/fail.php
+++ b/lib/event/domain/restore/fail.php
@@ -21,5 +21,7 @@ namespace Automattic\Domain_Services\Event\Domain\Restore;
 use Automattic\Domain_Services\{Event};
 
 class Fail implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait, Event\Error_Trait;
+	use Event\Data_Trait;
+	use Event\Error_Trait;
+	use Event\Object_Type_Domain_Trait;
 }

--- a/lib/event/domain/restore/success.php
+++ b/lib/event/domain/restore/success.php
@@ -21,7 +21,8 @@ namespace Automattic\Domain_Services\Event\Domain\Restore;
 use Automattic\Domain_Services\{Entity, Event};
 
 class Success implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Domain_Trait;
 
 	public function get_domain_status(): ?string {
 		return $this->get_data_by_key( 'event_data.domain_status' );

--- a/lib/event/domain/transfer/in/fail.php
+++ b/lib/event/domain/transfer/in/fail.php
@@ -21,5 +21,7 @@ namespace Automattic\Domain_Services\Event\Domain\Transfer\In;
 use Automattic\Domain_Services\{Entity, Event};
 
 class Fail implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait, Event\Transfer_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Domain_Trait;
+	use Event\Transfer_Trait;
 }

--- a/lib/event/domain/transfer/in/pending.php
+++ b/lib/event/domain/transfer/in/pending.php
@@ -21,5 +21,7 @@ namespace Automattic\Domain_Services\Event\Domain\Transfer\In;
 use Automattic\Domain_Services\{Event};
 
 class Pending implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait, Event\Transfer_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Domain_Trait;
+	use Event\Transfer_Trait;
 }

--- a/lib/event/domain/transfer/in/success.php
+++ b/lib/event/domain/transfer/in/success.php
@@ -21,5 +21,7 @@ namespace Automattic\Domain_Services\Event\Domain\Transfer\In;
 use Automattic\Domain_Services\{Event};
 
 class Success implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait, Event\Transfer_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Domain_Trait;
+	use Event\Transfer_Trait;
 }

--- a/lib/event/domain/transfer/out/fail.php
+++ b/lib/event/domain/transfer/out/fail.php
@@ -21,5 +21,7 @@ namespace Automattic\Domain_Services\Event\Domain\Transfer\Out;
 use Automattic\Domain_Services\{Event};
 
 class Fail implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait, Event\Transfer_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Domain_Trait;
+	use Event\Transfer_Trait;
 }

--- a/lib/event/domain/transfer/out/pending.php
+++ b/lib/event/domain/transfer/out/pending.php
@@ -21,5 +21,7 @@ namespace Automattic\Domain_Services\Event\Domain\Transfer\Out;
 use Automattic\Domain_Services\{Event};
 
 class Pending implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait, Event\Transfer_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Domain_Trait;
+	use Event\Transfer_Trait;
 }

--- a/lib/event/domain/transfer/out/success.php
+++ b/lib/event/domain/transfer/out/success.php
@@ -21,5 +21,7 @@ namespace Automattic\Domain_Services\Event\Domain\Transfer\Out;
 use Automattic\Domain_Services\{Event};
 
 class Success implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait, Event\Transfer_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Domain_Trait;
+	use Event\Transfer_Trait;
 }

--- a/lib/event/domain/transferlock/set/fail.php
+++ b/lib/event/domain/transferlock/set/fail.php
@@ -21,5 +21,7 @@ namespace Automattic\Domain_Services\Event\Domain\Transferlock\Set;
 use Automattic\Domain_Services\{Event};
 
 class Fail implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait, Event\Error_Trait;
+	use Event\Data_Trait;
+	use Event\Error_Trait;
+	use Event\Object_Type_Domain_Trait;
 }

--- a/lib/event/domain/transferlock/set/success.php
+++ b/lib/event/domain/transferlock/set/success.php
@@ -21,7 +21,8 @@ namespace Automattic\Domain_Services\Event\Domain\Transferlock\Set;
 use Automattic\Domain_Services\{Event};
 
 class Success implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+	use Event\Data_Trait;
+	use Event\Object_Type_Domain_Trait;
 
 	public function is_locked(): bool {
 		return $this->get_data_by_key( 'event_data.transferlock' ) ?? false;

--- a/lib/response/event/details.php
+++ b/lib/response/event/details.php
@@ -23,12 +23,14 @@ use Automattic\Domain_Services\{Event, Exception\Event\Invalid_Event_Name, Respo
 /**
  * Response of an Event_Details command.
  *
- * This is the response returned from a successful execution of Event_Details command. The event can be retrieved using get_event() method.
+ * This is the response returned from a successful execution of Event_Details command. The event can be retrieved using
+ * get_event() method.
  *
  * @see \Automattic\Domain_Services\Command\Event\Details
  */
 class Details implements Response\Response_Interface {
-	use Response\Data_Trait, Response\Event_Aware;
+	use Response\Data_Trait;
+	use Response\Event_Aware;
 
 	/**
 	 * Builds and returns an event entity

--- a/lib/response/events/get.php
+++ b/lib/response/events/get.php
@@ -30,7 +30,8 @@ use Automattic\Domain_Services\{Event, Exception, Response};
  * @see Event\Data_Trait
  */
 class Get implements Response\Response_Interface {
-	use Response\Data_Trait, Response\Event_Aware;
+	use Response\Data_Trait;
+	use Response\Event_Aware;
 
 	private const TOTAL_COUNT = 'data.total_count';
 	private const EVENTS = 'data.events';

--- a/test/command/dns-records-set-test.php
+++ b/test/command/dns-records-set-test.php
@@ -21,7 +21,10 @@ namespace Automattic\Domain_Services\Test\Command;
 use Automattic\Domain_Services\{Command, Entity, Test};
 
 class Dns_Records_Set_Test extends Test\Lib\Domain_Services_Client_Test_Case {
-	use Command\Array_Key_Dns_Record_Sets_Trait, Command\Array_Key_Domain_Trait, Command\Array_Key_Dns_Records_Trait, Command\Array_Key_Dns_Record_Sets_Trait;
+	use Command\Array_Key_Dns_Record_Sets_Trait;
+	use Command\Array_Key_Dns_Record_Sets_Trait;
+	use Command\Array_Key_Dns_Records_Trait;
+	use Command\Array_Key_Domain_Trait;
 
 	public function test_command_instance_success(): void {
 		$mock_command_data = [

--- a/test/command/domain-contacts-set-test.php
+++ b/test/command/domain-contacts-set-test.php
@@ -21,7 +21,11 @@ namespace Automattic\Domain_Services\Test\Command;
 use Automattic\Domain_Services\{Command, Entity, Test};
 
 class Domain_Contacts_Set_Test extends Test\Lib\Domain_Services_Client_Test_Case {
-	use Command\Array_Key_Domain_Trait, Command\Array_Key_Contacts_Trait, Command\Array_Key_Contact_Information_Trait, Command\Array_Key_Contact_Id_Trait, Command\Array_Key_Contact_Disclosure_Trait;
+	use Command\Array_Key_Contact_Disclosure_Trait;
+	use Command\Array_Key_Contact_Id_Trait;
+	use Command\Array_Key_Contact_Information_Trait;
+	use Command\Array_Key_Contacts_Trait;
+	use Command\Array_Key_Domain_Trait;
 
 	public function test_command_instance_success(): void {
 		$mock_command_data = [

--- a/test/command/domain-nameservers-set-test.php
+++ b/test/command/domain-nameservers-set-test.php
@@ -21,7 +21,8 @@ namespace Automattic\Domain_Services\Test\Command;
 use Automattic\Domain_Services\{Command, Entity, Test};
 
 class Domain_Nameservers_Set_Test extends Test\Lib\Domain_Services_Client_Test_Case {
-	use Command\Array_Key_Domain_Trait, Command\Array_Key_Nameservers_Trait;
+	use Command\Array_Key_Domain_Trait;
+	use Command\Array_Key_Nameservers_Trait;
 
 	public function test_command_instance_success(): void {
 		$mock_command_data = [

--- a/test/command/domain-privacy-set-test.php
+++ b/test/command/domain-privacy-set-test.php
@@ -21,7 +21,8 @@ namespace Automattic\Domain_Services\Test\Command;
 use Automattic\Domain_Services\{Command, Entity, Test};
 
 class Domain_Privacy_Set_Test extends Test\Lib\Domain_Services_Client_Test_Case {
-	use Command\Array_Key_Domain_Trait, Command\Array_Key_Privacy_Setting_Trait;
+	use Command\Array_Key_Domain_Trait;
+	use Command\Array_Key_Privacy_Setting_Trait;
 
 	public function test_command_instance_success(): void {
 		$mock_command_data = [

--- a/test/command/domain-register-test.php
+++ b/test/command/domain-register-test.php
@@ -21,7 +21,11 @@ namespace Automattic\Domain_Services\Test\Command;
 use Automattic\Domain_Services\{Command, Entity, Test};
 
 class Domain_Register_Test extends Test\Lib\Domain_Services_Client_Test_Case {
-	use Command\Array_Key_Domain_Trait, Command\Array_Key_Contacts_Trait, Command\Array_Key_Contact_Information_Trait, Command\Array_Key_Contact_Id_Trait, Command\Array_Key_Contact_Disclosure_Trait;
+	use Command\Array_Key_Contact_Disclosure_Trait;
+	use Command\Array_Key_Contact_Id_Trait;
+	use Command\Array_Key_Contact_Information_Trait;
+	use Command\Array_Key_Contacts_Trait;
+	use Command\Array_Key_Domain_Trait;
 
 	public function test_command_instance_success(): void {
 		$mock_command_data = [

--- a/test/command/domain-renew-test.php
+++ b/test/command/domain-renew-test.php
@@ -21,7 +21,10 @@ namespace Automattic\Domain_Services\Test\Command;
 use Automattic\Domain_Services\{Command, Entity, Test};
 
 class Domain_Renew_Test extends Test\Lib\Domain_Services_Client_Test_Case {
-	use Command\Array_Key_Domain_Trait, Command\Array_Key_Current_Expiration_Year_Trait, Command\Array_Key_Fee_Amount_Trait, Command\Array_Key_Period_Trait;
+	use Command\Array_Key_Current_Expiration_Year_Trait;
+	use Command\Array_Key_Domain_Trait;
+	use Command\Array_Key_Fee_Amount_Trait;
+	use Command\Array_Key_Period_Trait;
 
 	public function test_command_instance_success(): void {
 		$mock_command_data = [

--- a/test/command/domain-transferlock-set-test.php
+++ b/test/command/domain-transferlock-set-test.php
@@ -21,7 +21,8 @@ namespace Automattic\Domain_Services\Test\Command;
 use Automattic\Domain_Services\{Command, Entity, Test};
 
 class Domain_Transferlock_Set_Test extends Test\Lib\Domain_Services_Client_Test_Case {
-	use Command\Array_Key_Domain_Trait, Command\Array_Key_Transferlock_Trait;
+	use Command\Array_Key_Domain_Trait;
+	use Command\Array_Key_Transferlock_Trait;
 
 	public function test_command_instance_success(): void {
 		$mock_command_data = [


### PR DESCRIPTION
Some quick format updates to use one trait per line and make a couple of line-length updates.