### PR TITLE
Add expirationdate to domain info response

### DIFF
--- a/lib/response/domain/info.php
+++ b/lib/response/domain/info.php
@@ -58,6 +58,15 @@ class Info implements Response\Response_Interface {
 	}
 
 	/**
+	 * Gets the date the domain registration will expire
+	 *
+	 * @return string|null
+	 */
+	public function get_expiration_date(): ?string {
+		return $this->get_data_by_key( 'data.expiration_date' );
+	}
+
+	/**
 	 * Gets the DNSSec key data for the domain, if any exists
 	 *
 	 * @return string|null

--- a/test/response/domain-info-test.php
+++ b/test/response/domain-info-test.php
@@ -58,6 +58,7 @@ class Domain_Info_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 					],
 				],
 				'created_date' => '2022-06-22 01:23:45',
+				'expiration_date' => '2023-06-22 01:23:45',
 				'dnssec' => NULL,
 				'dnssec_ds_data' => NULL,
 				'epp_statuses' => [
@@ -88,6 +89,7 @@ class Domain_Info_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 
 		$this->assertEquals( $mock_response_data['data']['contacts'], $response_object->get_contacts()->to_array() );
 		$this->assertEquals( $mock_response_data['data']['created_date'], $response_object->get_created_date() );
+		$this->assertEquals( $mock_response_data['data']['expiration_date'], $response_object->get_expiration_date() );
 		$this->assertEquals( $mock_response_data['data']['dnssec'], $response_object->get_dnssec() );
 		$this->assertEquals( $mock_response_data['data']['dnssec_ds_data'], $response_object->get_dnssec_ds_dsata() );
 		$this->assertEquals( $mock_response_data['data']['epp_statuses'], $response_object->get_epp_statuses()->to_array() );


### PR DESCRIPTION
We now add this data on the server side, so we can make it available in the client too.