### PR TITLE
Renaming all of the Domain\Transferlock\Set namespaces to Domain\Set\Transferlock

### DIFF
--- a/lib/command/domain/set/transferlock.php
+++ b/lib/command/domain/set/transferlock.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command\Domain\Transferlock;
+namespace Automattic\Domain_Services\Command\Domain\Set;
 
 use Automattic\Domain_Services\{Command, Entity};
 
@@ -25,9 +25,9 @@ use Automattic\Domain_Services\{Command, Entity};
  *
  * This commands requests either enabling or disabling the transfer lock on a specific domain.
  *
- * @see \Automattic\Domain_Services\Response\Domain\Transferlock\Set
+ * @see \Automattic\Domain_Services\Response\Domain\Set\Transferlock
  */
-class Set implements Command\Command_Interface, Command\Command_Serialize_Interface {
+class Transferlock implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Trait;
 	use Command\Command_Serialize_Trait;
 	use Command\Array_Key_Domain_Trait;
@@ -49,7 +49,7 @@ class Set implements Command\Command_Interface, Command\Command_Serialize_Interf
 
 	/**
 	 * @param Entity\Domain_Name $domain
-	 * @param bool $transfer_lock
+	 * @param bool               $transfer_lock
 	 */
 	public function __construct( Entity\Domain_Name $domain, bool $transfer_lock ) {
 		$this->domain = $domain;
@@ -78,7 +78,7 @@ class Set implements Command\Command_Interface, Command\Command_Serialize_Interf
 	 * {@inheritDoc}
 	 */
 	public static function get_name(): string {
-		return 'Domain_Transferlock_Set';
+		return 'Domain_Set_Transferlock';
 	}
 
 	/**

--- a/lib/event/domain/set/transferlock/fail.php
+++ b/lib/event/domain/set/transferlock/fail.php
@@ -16,14 +16,10 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Transferlock\Set;
+namespace Automattic\Domain_Services\Event\Domain\Set\Transferlock;
 
 use Automattic\Domain_Services\{Event};
 
-class Success implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
-
-	public function is_locked(): bool {
-		return $this->get_data_by_key( 'event_data.transferlock' ) ?? false;
-	}
+class Fail implements Event\Event_Interface {
+	use Event\Data_Trait, Event\Object_Type_Domain_Trait, Event\Error_Trait;
 }

--- a/lib/event/domain/set/transferlock/success.php
+++ b/lib/event/domain/set/transferlock/success.php
@@ -16,15 +16,14 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response\Domain\Transferlock;
+namespace Automattic\Domain_Services\Event\Domain\Set\Transferlock;
 
-use Automattic\Domain_Services\Response;
+use Automattic\Domain_Services\{Event};
 
-/**
- * Response of a Transferlock\Set command.
- *
- * @see \Automattic\Domain_Services\Command\Domain\Transferlock\Set
- */
-class Set implements Response\Response_Interface {
-	use Response\Data_Trait;
+class Success implements Event\Event_Interface {
+	use Event\Data_Trait, Event\Object_Type_Domain_Trait;
+
+	public function is_locked(): bool {
+		return $this->get_data_by_key( 'event_data.transferlock' ) ?? false;
+	}
 }

--- a/lib/response/domain/set/transferlock.php
+++ b/lib/response/domain/set/transferlock.php
@@ -16,10 +16,15 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Transferlock\Set;
+namespace Automattic\Domain_Services\Response\Domain\Set;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services\Response;
 
-class Fail implements Event\Event_Interface {
-	use Event\Data_Trait, Event\Object_Type_Domain_Trait, Event\Error_Trait;
+/**
+ * Response of a Transferlock\Set command.
+ *
+ * @see \Automattic\Domain_Services\Command\Domain\Set\Transferlock
+ */
+class Transferlock implements Response\Response_Interface {
+	use Response\Data_Trait;
 }

--- a/test/command/domain-set-transferlock-test.php
+++ b/test/command/domain-set-transferlock-test.php
@@ -20,12 +20,12 @@ namespace Automattic\Domain_Services\Test\Command;
 
 use Automattic\Domain_Services\{Command, Entity, Test};
 
-class Domain_Transferlock_Set_Test extends Test\Lib\Domain_Services_Client_Test_Case {
+class Domain_Set_Transferlock_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	use Command\Array_Key_Domain_Trait, Command\Array_Key_Transferlock_Trait;
 
 	public function test_command_instance_success(): void {
 		$mock_command_data = [
-			Command\Command_Interface::COMMAND => 'Domain_Transferlock_Set',
+			Command\Command_Interface::COMMAND => 'Domain_Set_Transferlock',
 			Command\Command_Interface::PARAMS => [
 				self::get_domain_name_array_key() => 'test-domain-name.com',
 				self::get_transferlock_array_key() => true,
@@ -34,10 +34,10 @@ class Domain_Transferlock_Set_Test extends Test\Lib\Domain_Services_Client_Test_
 		];
 
 		$domain = new Entity\Domain_Name( $mock_command_data[ Command\Command_Interface::PARAMS ][ self::get_domain_name_array_key() ] );
-		$command = new Command\Domain\Transferlock\Set( $domain, $mock_command_data[ Command\Command_Interface::PARAMS ][ self::get_transferlock_array_key() ] );
+		$command = new Command\Domain\Set\Transferlock( $domain, $mock_command_data[ Command\Command_Interface::PARAMS ][ self::get_transferlock_array_key() ] );
 		$command->set_client_txn_id( $mock_command_data[ Command\Command_Interface::CLIENT_TXN_ID ] );
 
-		$this->assertInstanceOf( Command\Domain\Transferlock\Set::class, $command );
+		$this->assertInstanceOf( Command\Domain\Set\Transferlock::class, $command );
 
 		$actual_command_array = $command->jsonSerialize();
 

--- a/test/event/domain-set-transferlock-fail-test.php
+++ b/test/event/domain-set-transferlock-fail-test.php
@@ -20,7 +20,7 @@ namespace Automattic\Domain_Services\Test\Event;
 
 use Automattic\Domain_Services\{Command, Event, Response, Test};
 
-class Domain_Transferlock_Set_Success_Test extends Test\Lib\Domain_Services_Client_Test_Case {
+class Domain_Set_Transferlock_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {
 		$command = new Command\Event\Details( 1234 );
 
@@ -35,14 +35,21 @@ class Domain_Transferlock_Set_Success_Test extends Test\Lib\Domain_Services_Clie
 			'data' => [
 				'event' => [
 					'id' => 1234,
-					'event_class' => 'Domain_Transferlock_Set',
-					'event_subclass' => 'Success',
+					'event_class' => 'Domain_Set_Transferlock',
+					'event_subclass' => 'Fail',
 					'object_type' => 'domain',
 					'object_id' => 'example.com',
 					'event_date' => '2022-01-23 12:34:56',
 					'acknowledged_date' => null,
 					'event_data' => [
-						'transferlock' => true,
+						// TODO: Provide accurate error data once this is finalized in the server repo
+						'error' => [
+							'class' => '',
+							'subclass' => 'Domain_Services',
+							'data' => [
+								'reason' => 'Invalid domain state',
+							],
+						],
 					],
 				],
 			],
@@ -56,8 +63,8 @@ class Domain_Transferlock_Set_Success_Test extends Test\Lib\Domain_Services_Clie
 		$event = $response_object->get_event();
 		$this->assertNotNull( $event );
 
-		$this->assertInstanceOf( Event\Domain\Transferlock\Set\Success::class, $event );
-		$this->assertSame( $response_data['data']['event']['event_data']['transferlock'], $event->is_locked() );
+		$this->assertInstanceOf( Event\Domain\Set\Transferlock\Fail::class, $event );
 		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['reason'], $event->get_error_reason() );
 	}
 }

--- a/test/event/domain-set-transferlock-success-test.php
+++ b/test/event/domain-set-transferlock-success-test.php
@@ -20,7 +20,7 @@ namespace Automattic\Domain_Services\Test\Event;
 
 use Automattic\Domain_Services\{Command, Event, Response, Test};
 
-class Domain_Transferlock_Set_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case {
+class Domain_Set_Transferlock_Success_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {
 		$command = new Command\Event\Details( 1234 );
 
@@ -35,21 +35,14 @@ class Domain_Transferlock_Set_Fail_Test extends Test\Lib\Domain_Services_Client_
 			'data' => [
 				'event' => [
 					'id' => 1234,
-					'event_class' => 'Domain_Transferlock_Set',
-					'event_subclass' => 'Fail',
+					'event_class' => 'Domain_Set_Transferlock',
+					'event_subclass' => 'Success',
 					'object_type' => 'domain',
 					'object_id' => 'example.com',
 					'event_date' => '2022-01-23 12:34:56',
 					'acknowledged_date' => null,
 					'event_data' => [
-						// TODO: Provide accurate error data once this is finalized in the server repo
-						'error' => [
-							'class' => '',
-							'subclass' => 'Domain_Services',
-							'data' => [
-								'reason' => 'Invalid domain state',
-							],
-						],
+						'transferlock' => true,
 					],
 				],
 			],
@@ -63,8 +56,8 @@ class Domain_Transferlock_Set_Fail_Test extends Test\Lib\Domain_Services_Client_
 		$event = $response_object->get_event();
 		$this->assertNotNull( $event );
 
-		$this->assertInstanceOf( Event\Domain\Transferlock\Set\Fail::class, $event );
+		$this->assertInstanceOf( Event\Domain\Set\Transferlock\Success::class, $event );
+		$this->assertSame( $response_data['data']['event']['event_data']['transferlock'], $event->is_locked() );
 		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
-		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['reason'], $event->get_error_reason() );
 	}
 }

--- a/test/response/domain-set-transferlock-test.php
+++ b/test/response/domain-set-transferlock-test.php
@@ -20,10 +20,10 @@ namespace Automattic\Domain_Services\Test\Response;
 
 use Automattic\Domain_Services\{Command, Entity, Response, Test};
 
-class Domain_Transferlock_Set_Test extends Test\Lib\Domain_Services_Client_Test_Case {
+class Domain_Set_Transferlock_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_response_factory_success(): void {
 		$domain_name = new Entity\Domain_Name( 'test-domain-name.com' );
-		$command = new Command\Domain\Transferlock\Set( $domain_name, true );
+		$command = new Command\Domain\Set\Transferlock( $domain_name, true );
 
 		$response_data = [
 			'status' => 200,
@@ -35,10 +35,10 @@ class Domain_Transferlock_Set_Test extends Test\Lib\Domain_Services_Client_Test_
 			'runtime' => 0.0061,
 		];
 
-		/** @var Response\Domain\Transferlock\Set $response_object */
+		/** @var Response\Domain\Set\Transferlock $response_object */
 		$response_object = $this->response_factory->build_response( $command, $response_data );
 
-		$this->assertInstanceOf( Response\Domain\Transferlock\Set::class, $response_object );
+		$this->assertInstanceOf( Response\Domain\Set\Transferlock::class, $response_object );
 
 		$this->assertIsValidResponse( $response_data, $response_object );
 	}


### PR DESCRIPTION
This PR renames all of the Domain\Transferlock\Set namesaces to Domain\Set\Transferlock

Inspect the code; Run the unit tests:
```
composer update; ./vendor/bin/phpunit -c ./test/phpunit.xml
```