### PR TITLE
Update Events\Get to Event\Enumerate

### DIFF
--- a/lib/command/event/ack.php
+++ b/lib/command/event/ack.php
@@ -24,11 +24,11 @@ use Automattic\Domain_Services\{Command};
  * Acknowledge an event
  *
  *  - The command requests acknowledging a specific event by using the event ID.
- *  - IDs can be fetched using the `Events\Get` command.
+ *  - IDs can be fetched using the `Event\Enumerate` command.
  *  - This command executes synchronously on the server.
  *
  * @see \Automattic\Domain_Services\Response\Event\Ack
- * @see \Automattic\Domain_Services\Response\Events\Get
+ * @see \Automattic\Domain_Services\Response\Event\Enumerate
  */
 class Ack implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Trait, Command\Command_Serialize_Trait, Command\Array_Key_Event_Trait;

--- a/lib/command/event/details.php
+++ b/lib/command/event/details.php
@@ -24,12 +24,12 @@ use Automattic\Domain_Services\{Command};
  * Requests details of an event
  *
  *  - This command requests the details of a spcific event using its ID.
- *  - IDs can be fetched using the `Events\Get` command.
+ *  - IDs can be fetched using the `Event\Enumerate` command.
  *  - This command executes synchronously on the server.
  *  - The corresponding response object will include the details of an event.
  *
  * @see \Automattic\Domain_Services\Response\Event\Details
- * @see \Automattic\Domain_Services\Response\Events\Get
+ * @see \Automattic\Domain_Services\Response\Event\Enumerate
  */
 class Details implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Trait;

--- a/lib/command/event/enumerate.php
+++ b/lib/command/event/enumerate.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command\Events;
+namespace Automattic\Domain_Services\Command\Event;
 
 use Automattic\Domain_Services\{Command};
 
@@ -29,9 +29,9 @@ use Automattic\Domain_Services\{Command};
  * - This command executes synchronously on the server.
  * - The corresponding response object will include the list of events.
  *
- * @see \Automattic\Domain_Services\Response\Events\Get
+ * @see \Automattic\Domain_Services\Response\Event\Enumerate
  */
-class Get implements Command\Command_Interface, Command\Command_Serialize_Interface {
+class Enumerate implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Trait, Command\Command_Serialize_Trait, Command\Array_Key_Event_Trait;
 
 	/**
@@ -63,7 +63,7 @@ class Get implements Command\Command_Interface, Command\Command_Serialize_Interf
 	 * Sets the maximum number of events to return in the response.
 	 *
 	 * @param int $limit
-	 * @return Get
+	 * @return Enumerate
 	 */
 	public function set_limit( int $limit ): self {
 		$this->limit = $limit;
@@ -75,7 +75,7 @@ class Get implements Command\Command_Interface, Command\Command_Serialize_Interf
 	 * {@inheritDoc}
 	 */
 	public static function get_name(): string {
-		return 'Events_Get';
+		return 'Event_Enumerate';
 	}
 
 	/**

--- a/lib/response/event/enumerate.php
+++ b/lib/response/event/enumerate.php
@@ -16,20 +16,20 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response\Events;
+namespace Automattic\Domain_Services\Response\Event;
 
 use Automattic\Domain_Services\{Event, Exception, Response};
 
 /**
- * Response of Events\Get command
+ * Response of Event\Enumerate command
  *
- * This class encapsulates the data for a successful call to the Events\Get command. It includes a list of Event
+ * This class encapsulates the data for a successful call to the Event\Enumerate command. It includes a list of Event
  * objects which all implement the methods in Event\Data_Trait. Each individual event class may also implement
  * additional methods depending on the specific event_class and event_subclass properties of the event.
  *
  * @see Event\Data_Trait
  */
-class Get implements Response\Response_Interface {
+class Enumerate implements Response\Response_Interface {
 	use Response\Data_Trait, Response\Event_Aware;
 
 	private const TOTAL_COUNT = 'data.total_count';
@@ -63,7 +63,7 @@ class Get implements Response\Response_Interface {
 	}
 
 	/**
-	 * Gets the request parameters from the original Command\Events\Get request
+	 * Gets the request parameters from the original Command\Event\Enumerate request
 	 *
 	 * @return array
 	 */

--- a/test/command/event-enumerate-test.php
+++ b/test/command/event-enumerate-test.php
@@ -20,23 +20,23 @@ namespace Automattic\Domain_Services\Test\Command;
 
 use Automattic\Domain_Services\{Command, Entity, Test};
 
-class Events_Get_Test extends Test\Lib\Domain_Services_Client_Test_Case {
+class Event_Enumerate_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	use Command\Array_Key_Event_Trait;
 
 	public function test_command_instance_success(): void {
 		$mock_command_data = [
-			Command\Command_Interface::COMMAND => 'Events_Get',
+			Command\Command_Interface::COMMAND => 'Event_Enumerate',
 			Command\Command_Interface::PARAMS => [
 				self::get_event_limit_array_key() => 50,
 			],
-			Command\Command_Interface::CLIENT_TXN_ID => 'client-transaction-info-for-events-get-test-1',
+			Command\Command_Interface::CLIENT_TXN_ID => 'client-transaction-info-for-event-enumerate-test-1',
 		];
 
-		$command = new Command\Events\Get();
+		$command = new Command\Event\Enumerate();
 		$command->set_limit( $mock_command_data[ Command\Command_Interface::PARAMS ][ self::get_event_limit_array_key() ] );
 		$command->set_client_txn_id( $mock_command_data[ Command\Command_Interface::CLIENT_TXN_ID ] );
 
-		$this->assertInstanceOf( Command\Events\Get::class, $command );
+		$this->assertInstanceOf( Command\Event\Enumerate::class, $command );
 
 		$actual_command_array = $command->jsonSerialize();
 

--- a/test/lib/mock/response-data.php
+++ b/test/lib/mock/response-data.php
@@ -173,7 +173,7 @@ function get_mock_response( Command\Command_Interface $command, ?string $domain,
 			];
 			break;
 
-		case 'Events_Get-success':
+		case 'Event_Enumerate-success':
 			$response = [
 				'status' => 200,
 				'status_description' => 'Command completed successfully',

--- a/test/response/events-enumerate-test.php
+++ b/test/response/events-enumerate-test.php
@@ -20,18 +20,18 @@ namespace Automattic\Domain_Services\Test\Response;
 
 use Automattic\Domain_Services\{Command, Entity, Response, Test};
 
-class Events_Get_Test extends Test\Lib\Domain_Services_Client_Test_Case {
+class Event_Enumerate_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_response_factory_success(): void {
-		$command = new Command\Events\Get();
+		$command = new Command\Event\Enumerate();
 
 		$response_data = Test\Lib\Mock\get_mock_response( $command, null, 'success' );
 
-		/** @var Response\Events\Get $response_object */
+		/** @var Response\Event\Enumerate $response_object */
 		$response_object = $this->response_factory->build_response( $command, $response_data );
 
 		$this->assertIsValidResponse( $response_data, $response_object );
 
-		$this->assertInstanceOf( Response\Events\Get::class, $response_object );
+		$this->assertInstanceOf( Response\Event\Enumerate::class, $response_object );
 
 		$events = $response_object->get_events();
 		$request_params = $response_object->get_request_params();


### PR DESCRIPTION
This PR renames the Evetns\Get namespace to Event\Enumerate.

Inspect the code, run the unit tests:
```
composer update; ./vendor/bin/phpunit -c ./test/phpunit.xml
```