### PR TITLE
remove unused server code from entity classes

### DIFF
--- a/lib/entity/contact-disclosure.php
+++ b/lib/entity/contact-disclosure.php
@@ -52,25 +52,6 @@ class Contact_Disclosure {
 	}
 
 	/**
-	 * Generate the contact disclosure fields based on the given whois privacy settings.
-	 *
-	 * @param Whois_Privacy $whois_privacy
-	 * @return static
-	 * @throws Exception\Entity\Invalid_Value_Exception
-	 */
-	public static function build_from_whois_privacy( Whois_Privacy $whois_privacy ): self {
-		if ( Whois_Privacy::DISCLOSE_CONTACT_INFO === $whois_privacy->get_setting() ) {
-			return new self( self::ALL );
-		}
-
-		if ( in_array( $whois_privacy->get_setting(), [ Whois_Privacy::ENABLE_PRIVACY_SERVICE, Whois_Privacy::REDACT_CONTACT_INFO ], true ) ) {
-			return new self( self::NONE );
-		}
-
-		throw new Exception\Entity\Invalid_Value_Exception( __CLASS__, 'No corresponding contact disclosure value for the given whois privacy setting' );
-	}
-
-	/**
 	 * Get the disclosed fields as a comma delimited list.
 	 *
 	 * @return string

--- a/lib/entity/contact-id.php
+++ b/lib/entity/contact-id.php
@@ -29,8 +29,10 @@ use Automattic\Domain_Services\{Exception};
  * @see Domain_Contact
  */
 class Contact_Id implements Entity_Interface {
-	private string $provider_id;
-	private string $provider_contact_id;
+	/**
+	 * @var string
+	 */
+	private string $contact_id;
 
 	/**
 	 * Constructs a Contact_Id entity
@@ -46,37 +48,17 @@ class Contact_Id implements Entity_Interface {
 			throw new Exception\Entity\Invalid_Value_Exception( __CLASS__, 'Invalid contact ID format' );
 		}
 
-		$this->provider_id = $contact_id_parts[0];
-		$this->provider_contact_id = $contact_id_parts[1];
-
-		if ( ! in_array( $this->provider_id, Entity_Interface::VALID_PROVIDER_IDS, true ) ) {
-			throw new Exception\Entity\Invalid_Value_Exception( __CLASS__, 'Invalid contact ID prefix' );
-		}
-	}
-
-	private static function build_string( string $provider_id, string $provider_contact_id ): string {
-		return $provider_id . ':' . $provider_contact_id;
+		$this->contact_id = $contact_id;
 	}
 
 	public function __toString(): string {
-		return self::build_string( $this->provider_id, $this->provider_contact_id );
-	}
-
-	public static function build_for_provider( string $provider_id, string $provider_contact_id ): self {
-		return new self( self::build_string( $provider_id, $provider_contact_id ) );
+		return $this->get_contact_id();
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_provider_id(): string {
-		return $this->provider_id;
-	}
-
-	/**
-	 * @return string
-	 */
-	public function get_provider_contact_id(): string {
-		return $this->provider_contact_id;
+	public function get_contact_id(): string {
+		return $this->contact_id;
 	}
 }

--- a/lib/entity/entity-interface.php
+++ b/lib/entity/entity-interface.php
@@ -20,10 +20,4 @@ namespace Automattic\Domain_Services\Entity;
 
 interface Entity_Interface {
 	public const DATE_FORMAT = 'Y-m-d H:i:s';
-
-	public const SP1 = 'SP1';
-
-	public const VALID_PROVIDER_IDS = [
-		self::SP1,
-	];
 }

--- a/test/entity/contact-id-test.php
+++ b/test/entity/contact-id-test.php
@@ -22,50 +22,11 @@ use Automattic\Domain_Services\{Entity, Exception, Response, Test};
 
 class Contact_Id_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_entity_instance_success(): void {
-		$sp_id = Entity\Contact_Id::SP1;
-		$provider_contact_id = 'P-ABC1234';
-		$contact_id = $sp_id . ':' . $provider_contact_id;
+		$contact_id = 'SP1:P-ABC1234';
 
 		$entity = new Entity\Contact_Id( $contact_id );
 
-		$this->assertSame( $sp_id, $entity->get_provider_id() );
-		$this->assertSame( $provider_contact_id, $entity->get_provider_contact_id() );
 		$this->assertSame( $contact_id, (string) $entity );
-	}
-
-	public function test_entity_instance_build_for_provider_success(): void {
-		$sp_id = Entity\Contact_Id::SP1;
-		$provider_contact_id = 'P-ABC1234';
-		$contact_id = $sp_id . ':' . $provider_contact_id;
-
-		$entity = Entity\Contact_Id::build_for_provider( $sp_id, $provider_contact_id );
-
-		$this->assertSame( $sp_id, $entity->get_provider_id() );
-		$this->assertSame( $provider_contact_id, $entity->get_provider_contact_id() );
-		$this->assertSame( $contact_id, (string) $entity );
-	}
-
-	public function test_entity_instance_fail_invalid_sp_id(): void {
-		$sp_id = 'invalid_sp_id';
-		$provider_contact_id = 'P-ABC1234';
-		$contact_id = $sp_id . ':' . $provider_contact_id;
-
-		$this->expectException( Exception\Entity\Invalid_Value_Exception::class );
-		$this->expectExceptionCode( Response\Code::INVALID_ENTITY_VALUE );
-		$this->expectExceptionMessage( Response\Code::get_description( Response\Code::INVALID_ENTITY_VALUE ) );
-
-		new Entity\Contact_Id( $contact_id );
-	}
-
-	public function test_entity_instance_build_for_provider_fail_invalid_sp_id(): void {
-		$sp_id = 'invalid_sp_id';
-		$provider_contact_id = 'P-ABC1234';
-
-		$this->expectException( Exception\Entity\Invalid_Value_Exception::class );
-		$this->expectExceptionCode( Response\Code::INVALID_ENTITY_VALUE );
-		$this->expectExceptionMessage( Response\Code::get_description( Response\Code::INVALID_ENTITY_VALUE ) );
-
-		Entity\Contact_Id::build_for_provider( $sp_id, $provider_contact_id );
 	}
 
 	public function test_entity_instance_fail_invalid_contact_id_format(): void {


### PR DESCRIPTION
Some of the entities had code that was only relevant on the server side. This PR removes that code.

## Testing
Using unit tests `./vendor/bin/phpunit -c ./test/phpunit.xml`