### PR TITLE
Add a Domain\Suggestions command

### DIFF
--- a/lib/command/command-interface.php
+++ b/lib/command/command-interface.php
@@ -39,6 +39,8 @@ interface Command_Interface {
 	public const KEY_NAMESERVERS = 'nameservers';
 	public const KEY_PERIOD = 'period';
 	public const KEY_PRIVACY_SETTINGS = 'privacy_setting';
+	public const KEY_QUANTITY = 'quantity';
+	public const KEY_QUERY = 'query';
 	public const KEY_RECORD_SETS = 'record_sets';
 	public const KEY_RECORDS = 'records';
 	public const KEY_TRANSFERLOCK = 'transferlock';

--- a/lib/command/domain/suggestions.php
+++ b/lib/command/domain/suggestions.php
@@ -1,0 +1,80 @@
+<?php declare( strict_types=1 );
+/*
+ * Copyright (c) 2023 Automattic, Inc.
+ *
+ * This file is part of the Automattic Domain Services Client library.
+ *
+ * The Automattic Domain Services Client library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program;
+ * if not, see https://www.gnu.org/licenses.
+ */
+
+namespace Automattic\Domain_Services\Command\Domain;
+
+use Automattic\Domain_Services\{Command};
+
+/**
+ * Retrieves a list of domain name suggestions based on a query string
+ *
+ * @see \Automattic\Domain_Services\Response\Domain\Suggestions
+ */
+class Suggestions implements Command\Command_Interface, Command\Command_Serialize_Interface {
+	use Command\Command_Serialize_Trait;
+	use Command\Command_Trait;
+
+	/**
+	 * @var string query string used to retrieve suggestions
+	 */
+	private string $query;
+
+	/**
+	 * @var int number of domain suggestions to retrieve
+	 */
+	private int $quantity;
+
+	/**
+	 * Constructs a Domain\Suggestions command
+	 *
+	 * @param string $query
+	 * @param int    $quantity
+	 */
+	public function __construct( string $query, int $quantity ) {
+		$this->query = $query;
+		$this->quantity = $quantity;
+	}
+
+	/**
+	 * Returns the query string used to get suggestions
+	 *
+	 * @return string
+	 */
+	public function get_query(): string {
+		return $this->query;
+	}
+
+	/**
+	 * Returns the quantity of suggestions to generate
+	 *
+	 * @return int
+	 */
+	public function get_quantity(): int {
+		return $this->quantity;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function to_array(): array {
+		return [
+			'query' => $this->query,
+			'quantity' => $this->quantity,
+		];
+	}
+}

--- a/lib/command/domain/suggestions.php
+++ b/lib/command/domain/suggestions.php
@@ -73,8 +73,8 @@ class Suggestions implements Command\Command_Interface, Command\Command_Serializ
 	 */
 	public function to_array(): array {
 		return [
-			'query' => $this->query,
-			'quantity' => $this->quantity,
+			Command\Command_Interface::KEY_QUERY => $this->query,
+			Command\Command_Interface::KEY_QUANTITY => $this->quantity,
 		];
 	}
 }

--- a/lib/entity/domain-suggestion.php
+++ b/lib/entity/domain-suggestion.php
@@ -1,0 +1,62 @@
+<?php declare( strict_types=1 );
+/*
+ * Copyright (c) 2023 Automattic, Inc.
+ *
+ * This file is part of the Automattic Domain Services Client library.
+ *
+ * The Automattic Domain Services Client library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program;
+ * if not, see https://www.gnu.org/licenses.
+ */
+
+namespace Automattic\Domain_Services\Entity;
+
+/**
+ * Domain name suggestion
+ *
+ * Used in the `Domain\Suggestions` response.
+ *
+ * @see \Automattic\Domain_Services\Response\Domain\Suggestions
+ */
+class Suggestion {
+	/**
+	 * @var Domain_Name a domain name suggestion
+	 */
+	private Domain_Name $domain_name;
+
+	/**
+	 * Constructs a Suggestion entity
+	 *
+	 * @param Domain_Name $domain_name
+	 */
+	public function __construct( Domain_Name $domain_name ) {
+		$this->domain_name = $domain_name;
+	}
+
+	/**
+	 * Returns the domain name suggestion
+	 *
+	 * @return Domain_Name
+	 */
+	public function get_domain_name(): Domain_Name {
+		return $this->domain_name;
+	}
+
+	/**
+	 * Returns an associative array containing the domain name suggestion
+	 *
+	 * @return array
+	 */
+	public function to_array(): array {
+		return [
+			'name' => $this->domain_name->get_name(),
+		];
+	}
+}

--- a/lib/entity/domain-suggestions.php
+++ b/lib/entity/domain-suggestions.php
@@ -1,0 +1,79 @@
+<?php declare( strict_types=1 );
+/*
+ * Copyright (c) 2023 Automattic, Inc.
+ *
+ * This file is part of the Automattic Domain Services Client library.
+ *
+ * The Automattic Domain Services Client library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program;
+ * if not, see https://www.gnu.org/licenses.
+ */
+
+namespace Automattic\Domain_Services\Entity;
+
+/**
+ * List of Suggestion entities
+ *
+ * Used in the `Domain\Suggestions` response.
+ *
+ * @see \Automattic\Domain_Services\Entity\Suggestion
+ * @see \Automattic\Domain_Services\Response\Domain\Suggestions
+ */
+class Suggestions {
+	/**
+	 * List of Suggestion entities
+	 *
+	 * @var Suggestion[]
+	 */
+	private array $suggestions = [];
+
+	/**
+	 * Constructs a Suggestions entity
+	 *
+	 * @param Suggestion ...$suggestions
+	 */
+	public function __construct( Suggestion ...$suggestions ) {
+		$this->suggestions = $suggestions;
+	}
+
+	/**
+	 * Adds a new Suggestion to the list of suggestions
+	 *
+	 * @param Suggestion $suggestion
+	 * @return $this
+	 */
+	public function add_suggestion( Suggestion $suggestion ): self {
+		$this->suggestions[] = $suggestion;
+
+		return $this;
+	}
+
+	/**
+	 * Returns the suggestions array
+	 *
+	 * @return Suggestions[]
+	 */
+	public function get_suggestions(): array {
+		return $this->suggestions;
+	}
+
+	/**
+	 * Returns an array containing this entity's domain name suggestions
+	 *
+	 * @return array
+	 */
+	public function to_array(): array {
+		$suggestions = [];
+		foreach ( $this->suggestions as $suggestion ) {
+			$suggestions[] = $suggestion->to_array();
+		}
+		return [ 'suggestions' => $suggestions ];
+	}
+}

--- a/lib/response/domain/suggestions.php
+++ b/lib/response/domain/suggestions.php
@@ -1,0 +1,48 @@
+<?php declare( strict_types=1 );
+/*
+ * Copyright (c) 2023 Automattic, Inc.
+ *
+ * This file is part of the Automattic Domain Services Client library.
+ *
+ * The Automattic Domain Services Client library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program;
+ * if not, see https://www.gnu.org/licenses.
+ */
+
+namespace Automattic\Domain_Services\Response\Domain;
+
+use Automattic\Domain_Services\{Entity, Response};
+use http\Encoding\Stream\Enbrotli;
+
+/**
+ * Response of a Domain_Suggestions command
+ *
+ * @see \Automattic\Domain_Services\Command\Domain\Suggestions
+ */
+class Suggestions implements Response\Response_Interface {
+	use Response\Data_Trait;
+
+	/**
+	 * Returns the suggestions of the response object
+	 *
+	 * @return Entity\Suggestions|null
+	 */
+	public function get_suggestions(): Entity\Suggestions {
+		$suggestions_data = $this->get_data_by_key( 'data.suggestions' );
+
+		$suggestions = new Entity\Suggestions();
+		foreach ( $suggestions_data as $suggestion_data ) {
+			$domain_name = new Entity\Domain_Name( $suggestion_data['name'] );
+			$suggestions->add_suggestion( new Entity\Suggestion( $domain_name ) );
+		}
+
+		return $suggestions;
+	}
+}

--- a/lib/response/domain/suggestions.php
+++ b/lib/response/domain/suggestions.php
@@ -19,7 +19,6 @@
 namespace Automattic\Domain_Services\Response\Domain;
 
 use Automattic\Domain_Services\{Entity, Response};
-use http\Encoding\Stream\Enbrotli;
 
 /**
  * Response of a Domain_Suggestions command

--- a/test/command/domain-suggestions-test.php
+++ b/test/command/domain-suggestions-test.php
@@ -1,0 +1,47 @@
+<?php declare( strict_types=1 );
+/*
+ * Copyright (c) 2022-2023 Automattic, Inc.
+ *
+ * This file is part of the Automattic Domain Services Client library.
+ *
+ * The Automattic Domain Services Client library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program;
+ * if not, see https://www.gnu.org/licenses.
+ */
+
+namespace Automattic\Domain_Services\Test\Command;
+
+use Automattic\Domain_Services\{Command, Entity, Test};
+
+class Domain_Suggestions_Test extends Test\Lib\Domain_Services_Client_Test_Case {
+
+	public function test_command_instance_success(): void {
+		$mock_command_data = [
+			Command\Command_Interface::COMMAND => 'Domain\Suggestions',
+			Command\Command_Interface::PARAMS => [
+				Command\Command_Interface::KEY_QUERY => 'some query string',
+				Command\Command_Interface::KEY_QUANTITY => 10,
+			],
+			Command\Command_Interface::CLIENT_TXN_ID => 'client-transaction-info-for-domain-suggestions-test-1',
+		];
+
+		$command = new Command\Domain\Suggestions(
+			$mock_command_data[ Command\Command_Interface::PARAMS ][ Command\Command_Interface::KEY_QUERY ],
+			$mock_command_data[ Command\Command_Interface::PARAMS ][ Command\Command_Interface::KEY_QUANTITY ]
+		);
+		$command->set_client_txn_id( $mock_command_data[ Command\Command_Interface::CLIENT_TXN_ID ] );
+
+		$this->assertInstanceOf( Command\Domain\Suggestions::class, $command );
+
+		$actual_command_array = $command->jsonSerialize();
+
+		$this->assertSame( $mock_command_data, $actual_command_array );
+	}
+}

--- a/test/command/domain-suggestions-test.php
+++ b/test/command/domain-suggestions-test.php
@@ -18,7 +18,7 @@
 
 namespace Automattic\Domain_Services\Test\Command;
 
-use Automattic\Domain_Services\{Command, Entity, Test};
+use Automattic\Domain_Services\{Command, Test};
 
 class Domain_Suggestions_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 

--- a/test/entity/domain-suggestions-test.php
+++ b/test/entity/domain-suggestions-test.php
@@ -1,0 +1,32 @@
+<?php declare( strict_types=1 );
+/*
+ * Copyright (c) 2023 Automattic, Inc.
+ *
+ * This file is part of the Automattic Domain Services Client library.
+ *
+ * The Automattic Domain Services Client library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program;
+ * if not, see https://www.gnu.org/licenses.
+ */
+
+namespace Automattic\Domain_Services\Test\Entity;
+
+use Automattic\Domain_Services\{Entity, Exception, Response, Test};
+
+class Domain_Suggestions_Test extends Test\Lib\Domain_Services_Client_Test_Case {
+	public function test_entity_instance_success(): void {
+		$domain_suggestion_data = array_map( static fn( $i ) => [ 'name' => "example$i.blog" ], range( 1, 10 ) );
+		$domain_name_list = array_map( static fn( $n ) => new Entity\Domain_Name( $n['name'] ), $domain_suggestion_data );
+		$suggestion_list = array_map( static fn( $d ) => new Entity\Suggestion( $d ), $domain_name_list );
+		$suggestions = new Entity\Suggestions( ... $suggestion_list );
+
+		$this->assertArraysEqual( $domain_suggestion_data, $suggestions->to_array()['suggestions'] );
+	}
+}

--- a/test/entity/domain-suggestions-test.php
+++ b/test/entity/domain-suggestions-test.php
@@ -18,7 +18,7 @@
 
 namespace Automattic\Domain_Services\Test\Entity;
 
-use Automattic\Domain_Services\{Entity, Exception, Response, Test};
+use Automattic\Domain_Services\{Entity, Test};
 
 class Domain_Suggestions_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_entity_instance_success(): void {

--- a/test/response/domain-suggestions-test.php
+++ b/test/response/domain-suggestions-test.php
@@ -1,0 +1,48 @@
+<?php declare( strict_types=1 );
+/*
+ * Copyright (c) 2022 Automattic, Inc.
+ *
+ * This file is part of the Automattic Domain Services Client library.
+ *
+ * The Automattic Domain Services Client library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program;
+ * if not, see https://www.gnu.org/licenses.
+ */
+
+namespace Automattic\Domain_Services\Test\Response;
+
+use Automattic\Domain_Services\{Command, Entity, Response, Test};
+
+class Domain_Suggestions_Test extends Test\Lib\Domain_Services_Client_Test_Case {
+	public function test_response_factory_success(): void {
+		$response_data = [
+			'status' => 200,
+			'status_description' => 'Command completed successfully',
+			'success' => true,
+			'client_txn_id' => 'test-client-transaction-id-1',
+			'server_txn_id' => '6e3f18b1-330c-4f6a-b780-351b999c9bb6.local-isolated-test-request',
+			'timestamp' => 1669075520,
+			'runtime' => 0.0021,
+			'data' => [
+				'suggestions' => array_map( static fn( $i ) => [ 'name' => "example$i.blog" ], range( 1, 10 ) ),
+			],
+		];
+
+		$command = new Command\Domain\Suggestions( 'example query', 10 );
+
+		/** @var Response\Domain\Suggestions $response_object */
+		$response_object = $this->response_factory->build_response( $command, $response_data );
+
+		$this->assertInstanceOf( Response\Domain\Suggestions::class, $response_object );
+		$this->assertIsValidResponse( $response_data, $response_object );
+		$this->assertArraysEqual( $response_data['data'], $response_object->get_suggestions()->to_array() );
+	}
+}
+

--- a/test/response/domain-suggestions-test.php
+++ b/test/response/domain-suggestions-test.php
@@ -18,7 +18,7 @@
 
 namespace Automattic\Domain_Services\Test\Response;
 
-use Automattic\Domain_Services\{Command, Entity, Response, Test};
+use Automattic\Domain_Services\{Command, Response, Test};
 
 class Domain_Suggestions_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_response_factory_success(): void {


### PR DESCRIPTION
This PR adds the `Domain\Suggestions` command to the client library.

Inspect the code, run the unit tests.

```composer update; ./vendor/bin/phpunit -c ./test/phpunit.xml```