### PR TITLE
Add base code for E2E tests and simple tests for `Domain\Suggestions`

### DIFF
--- a/test/e2e/domain-suggestions-e2e-test.php
+++ b/test/e2e/domain-suggestions-e2e-test.php
@@ -26,10 +26,10 @@ use Automattic\Domain_Services\{Command, Entity, Response, Test};
  * Run with
  *     ./vendor/bin/phpunit -c ./test/phpunit-e2e.xml --filter Suggestions_E2E_Test
  */
-class Domain_Suggestions_E2E_Test extends Test\Lib\Domain_Services_Client_E2e_Test_Case {
+class Domain_Suggestions_E2e_Test extends Test\Lib\Domain_Services_Client_E2e_Test_Case {
 
 	public function test_suggestions_success(): void {
-		$command = new Command\Domain\Suggestions( 'test-domain-suggestions-query', 5 );
+		$command = new Command\Domain\Suggestions( 'test domain suggestions query', 5 );
 		$client_transaction_id = $this->generate_client_transaction_id();
 
 		/** @var Response\Domain\Suggestions $response */

--- a/test/e2e/domain-suggestions-e2e-test.php
+++ b/test/e2e/domain-suggestions-e2e-test.php
@@ -21,12 +21,12 @@ namespace Automattic\Domain_Services\Test\Api;
 use Automattic\Domain_Services\{Command, Entity, Response, Test};
 
 /**
- * Run tests with
+ * E2E tests for the Domain\Suggestions command
  *
- *     ./vendor/bin/phpunit -c ./test/phpunit.xml --filter Suggestions_E2E_Test
+ * Run with
+ *     ./vendor/bin/phpunit -c ./test/phpunit-e2e.xml --filter Suggestions_E2E_Test
  */
 class Domain_Suggestions_E2E_Test extends Test\Lib\Domain_Services_Client_E2e_Test_Case {
-
 
 	public function test_suggestions_success(): void {
 		$command = new Command\Domain\Suggestions( 'test-domain-suggestions-query', 5 );

--- a/test/e2e/domain-suggestions-e2e-test.php
+++ b/test/e2e/domain-suggestions-e2e-test.php
@@ -1,0 +1,63 @@
+<?php declare( strict_types=1 );
+/*
+ * Copyright (c) 2022 Automattic, Inc.
+ *
+ * This file is part of the Automattic Domain Services Client library.
+ *
+ * The Automattic Domain Services Client library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program;
+ * if not, see https://www.gnu.org/licenses.
+ */
+
+namespace Automattic\Domain_Services\Test\Api;
+
+use Automattic\Domain_Services\{Command, Entity, Response, Test};
+
+/**
+ * Run tests with
+ *
+ *     ./vendor/bin/phpunit -c ./test/phpunit.xml --filter Suggestions_E2E_Test
+ */
+class Domain_Suggestions_E2E_Test extends Test\Lib\Domain_Services_Client_E2e_Test_Case {
+
+
+	public function test_suggestions_success(): void {
+		$command = new Command\Domain\Suggestions( 'test-domain-suggestions-query', 5 );
+		$client_transaction_id = $this->generate_client_transaction_id();
+
+		/** @var Response\Domain\Suggestions $response */
+		$response = $this->api->post( $command, $client_transaction_id );
+
+		$this->assertSame( Response\Code::SUCCESS, $response->get_status() );
+		$this->assertTrue( $response->is_success() );
+		$this->assertSame( $client_transaction_id, $response->get_client_txn_id() );
+
+		$suggestions = $response->get_suggestions();
+		$this->assertInstanceOf( Entity\Suggestions::class, $suggestions );
+		$this->assertCount( 5, $suggestions->get_suggestions() );
+	}
+
+	public function test_suggestions_with_no_query(): void {
+		$command = new Command\Domain\Suggestions( '', 5 );
+		$client_transaction_id = $this->generate_client_transaction_id();
+
+		/** @var Response\Domain\Suggestions $response */
+		$response = $this->api->post( $command, $client_transaction_id );
+
+		$this->assertSame( Response\Code::SUCCESS, $response->get_status() );
+		$this->assertTrue( $response->is_success() );
+		$this->assertSame( $client_transaction_id, $response->get_client_txn_id() );
+
+		$suggestions = $response->get_suggestions();
+		$this->assertInstanceOf( Entity\Suggestions::class, $suggestions );
+		$this->assertCount( 0, $suggestions->get_suggestions() );
+	}
+
+}

--- a/test/e2e/domain-suggestions-e2e-test.php
+++ b/test/e2e/domain-suggestions-e2e-test.php
@@ -24,7 +24,7 @@ use Automattic\Domain_Services\{Command, Entity, Response, Test};
  * E2E tests for the Domain\Suggestions command
  *
  * Run with
- *     ./vendor/bin/phpunit -c ./test/phpunit-e2e.xml --filter Suggestions_E2E_Test
+ *     ./vendor/bin/phpunit -c ./test/phpunit-e2e.xml --filter Domain_Suggestions_E2e_Test
  */
 class Domain_Suggestions_E2e_Test extends Test\Lib\Domain_Services_Client_E2e_Test_Case {
 

--- a/test/lib/domain-services-client-e2e-test-case.php
+++ b/test/lib/domain-services-client-e2e-test-case.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare( strict_types=1 );
 /*
  * Copyright (c) 2022 Automattic, Inc.
  *
@@ -16,7 +16,29 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-require_once __DIR__ . '/mock/load.php';
+namespace Automattic\Domain_Services\Test\Lib;
 
-require_once __DIR__ . '/domain-services-client-test-case.php';
-require_once __DIR__ . '/domain-services-client-e2e-test-case.php';
+use Automattic\Domain_Services\{Api, Configuration, Request, Response};
+
+class Domain_Services_Client_E2e_Test_Case extends Domain_Services_Client_Test_Case {
+	protected Api $api;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$config = Configuration::get_default_configuration()
+			->set_api_key( 'X-DSAPI-KEY', 'dsapi_key' ) // put test credentials here
+			->set_api_key( 'X-DSAPI-USER', 'dsapi_user' );
+
+		$guzzle_http_client = new \GuzzleHttp\Client();
+		$http_factory = new \GuzzleHttp\Psr7\HttpFactory();
+		$request_factory = new Request\Factory( $http_factory, $http_factory );
+
+		$this->api = new Api(
+			$config,
+			$request_factory,
+			new Response\Factory(),
+			$guzzle_http_client,
+		);
+	}
+}

--- a/test/lib/domain-services-client-test-case.php
+++ b/test/lib/domain-services-client-test-case.php
@@ -65,4 +65,8 @@ class Domain_Services_Client_Test_Case extends \PHPUnit\Framework\TestCase {
 
 		$this->assertEquals( $expected, $actual, $message );
 	}
+
+	public function generate_client_transaction_id(): string {
+		return 'client_txn_id_' . date( 'Y-m-d_H:i:s' );
+	}
 }

--- a/test/phpunit-e2e.xml
+++ b/test/phpunit-e2e.xml
@@ -25,20 +25,8 @@
 		convertWarningsToExceptions="false"
 		bootstrap="bootstrap.php">
 	<testsuites>
-		<testsuite name="command">
-			<directory suffix="test.php">command</directory>
-		</testsuite>
-		<testsuite name="entity">
-			<directory suffix="test.php">entity</directory>
-		</testsuite>
-		<testsuite name="event">
-			<directory suffix="test.php">event</directory>
-		</testsuite>
-		<testsuite name="response">
-			<directory suffix="test.php">response</directory>
-		</testsuite>
-		<testsuite name="api">
-			<directory suffix="test.php">api</directory>
+		<testsuite name="e2e">
+			<directory suffix="test.php">e2e</directory>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -40,5 +40,8 @@
 		<testsuite name="api">
 			<directory suffix="test.php">api</directory>
 		</testsuite>
+		<testsuite name="e2e">
+			<directory suffix="test.php">e2e</directory>
+		</testsuite>
 	</testsuites>
 </phpunit>


### PR DESCRIPTION
This PR adds code to enable E2E/integration testing with the actual backend code. It creates a separate `e2e` test suite so these more costly tests can be run separately from the other ones.

It also adds some tests for the `Domain\Suggestions` command which can be used as a base for other E2E tests.

### Testing

- Update test credentials in the `Domain_Services_Client_E2e_Test_Case` class
- Run the E2E test suite with
```
./vendor/bin/phpunit -c ./test/phpunit-e2e.xml
```