### PR TITLE
Rename namespace to `Automattic\Domain_Services_Client`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Please follow the [installation procedure](#installation--usage) and then run th
 // Change the path as necessary
 require_once 'vendor/autoload.php';
 
-use Automattic\Domain_Services\{Api, Command, Configuration, Entity, Response};
+use Automattic\Domain_Services_Client\{Api, Command, Configuration, Entity, Response};
 
 // Set the domain to use
 $domain_name = new Entity\Domain_Name( 'a8ctest.com' );
@@ -80,7 +80,7 @@ $domain_contacts = new Entity\Domain_Contacts(
 			'+1.7575551234',
 			''
 		),
-		new Entity\Contact_Disclosure( \Automattic\Domain_Services\Entity\Contact_Disclosure::NONE )
+		new Entity\Contact_Disclosure( \Automattic\Domain_Services_Client\Entity\Contact_Disclosure::NONE )
 	)
 );
 

--- a/dev-tools/examples/guzzle-6.php
+++ b/dev-tools/examples/guzzle-6.php
@@ -17,7 +17,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-use Automattic\Domain_Services\{Api, Command, Configuration, Entity, Response, Exception};
+use Automattic\Domain_Services_Client\{Api, Command, Configuration, Entity, Response, Exception};
 use \Http\Factory\Guzzle\{RequestFactory, StreamFactory};
 use \Http\Adapter\Guzzle6\Client;
 

--- a/dev-tools/examples/guzzle-7.php
+++ b/dev-tools/examples/guzzle-7.php
@@ -17,7 +17,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-use Automattic\Domain_Services\{Api, Command, Configuration, Entity, Response, Exception};
+use Automattic\Domain_Services_Client\{Api, Command, Configuration, Entity, Response, Exception};
 use GuzzleHttp\Psr7\HttpFactory;
 use GuzzleHttp\Client;
 

--- a/lib/api.php
+++ b/lib/api.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services;
+namespace Automattic\Domain_Services_Client;
 
-use Automattic\Domain_Services\{Command, Exception, Response, Request};
+use Automattic\Domain_Services_Client\{Command, Exception, Response, Request};
 use Psr\Http\Client;
 
 class Api {

--- a/lib/command/command-interface.php
+++ b/lib/command/command-interface.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command;
+namespace Automattic\Domain_Services_Client\Command;
 
 interface Command_Interface {
 	public const COMMAND = 'command';

--- a/lib/command/command-serialize-interface.php
+++ b/lib/command/command-serialize-interface.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command;
+namespace Automattic\Domain_Services_Client\Command;
 
 interface Command_Serialize_Interface extends \JsonSerializable {
 	/**

--- a/lib/command/command-serialize-trait.php
+++ b/lib/command/command-serialize-trait.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command;
+namespace Automattic\Domain_Services_Client\Command;
 
 trait Command_Serialize_Trait {
 	/**

--- a/lib/command/command-trait.php
+++ b/lib/command/command-trait.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command;
+namespace Automattic\Domain_Services_Client\Command;
 
 trait Command_Trait {
 	private string $client_txn_id = '';

--- a/lib/command/contact/details.php
+++ b/lib/command/contact/details.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command\Contact;
+namespace Automattic\Domain_Services_Client\Command\Contact;
 
-use Automattic\Domain_Services\{Command, Entity};
+use Automattic\Domain_Services_Client\{Command, Entity};
 
 /**
  * Retrieves the details of a contact by ID
@@ -37,8 +37,8 @@ use Automattic\Domain_Services\{Command, Entity};
  * }
  * ```
  *
- * @see \Automattic\Domain_Services\Response\Contact\Details
- * @see \Automattic\Domain_Services\Command\Domain\Set\Contacts
+ * @see \Automattic\Domain_Services_Client\Response\Contact\Details
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Set\Contacts
  */
 class Details implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Serialize_Trait;

--- a/lib/command/dns/get.php
+++ b/lib/command/dns/get.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command\Dns;
+namespace Automattic\Domain_Services_Client\Command\Dns;
 
-use Automattic\Domain_Services\{Command, Entity};
+use Automattic\Domain_Services_Client\{Command, Entity};
 
 /**
  * Returns the DNS records of a domain
@@ -40,8 +40,8 @@ use Automattic\Domain_Services\{Command, Entity};
  * }
  * ```
  *
- * @see \Automattic\Domain_Services\Response\Dns\Get
- * @see \Automattic\Domain_Services\Command\Dns\Set
+ * @see \Automattic\Domain_Services_Client\Response\Dns\Get
+ * @see \Automattic\Domain_Services_Client\Command\Dns\Set
  */
 class Get implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Serialize_Trait;

--- a/lib/command/dns/set.php
+++ b/lib/command/dns/set.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command\Dns;
+namespace Automattic\Domain_Services_Client\Command\Dns;
 
-use Automattic\Domain_Services\{Command, Entity};
+use Automattic\Domain_Services_Client\{Command, Entity};
 
 /**
  * Updates DNS records of a domain
@@ -59,8 +59,8 @@ use Automattic\Domain_Services\{Command, Entity};
  * }
  * ```
  *
- * @see \Automattic\Domain_Services\Command\Dns\Get
- * @see \Automattic\Domain_Services\Response\Dns\Set
+ * @see \Automattic\Domain_Services_Client\Command\Dns\Get
+ * @see \Automattic\Domain_Services_Client\Response\Dns\Set
  */
 class Set implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Serialize_Trait;

--- a/lib/command/domain/check.php
+++ b/lib/command/domain/check.php
@@ -16,16 +16,16 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command\Domain;
+namespace Automattic\Domain_Services_Client\Command\Domain;
 
-use Automattic\Domain_Services\{Command, Entity, Exception};
+use Automattic\Domain_Services_Client\{Command, Entity, Exception};
 
 /**
  * Checks the price and availability for a list of domain names
  *
  * This command requests an availability and price check for the list of supplied domain names.
  *
- * @see \Automattic\Domain_Services\Response\Domain\Check
+ * @see \Automattic\Domain_Services_Client\Response\Domain\Check
  */
 class Check implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Serialize_Trait;

--- a/lib/command/domain/delete.php
+++ b/lib/command/domain/delete.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command\Domain;
+namespace Automattic\Domain_Services_Client\Command\Domain;
 
-use Automattic\Domain_Services\{Command, Entity};
+use Automattic\Domain_Services_Client\{Command, Entity};
 
 /**
  * Deletes a domain
@@ -43,9 +43,9 @@ use Automattic\Domain_Services\{Command, Entity};
  * }
  * ```
  *
- * @see \Automattic\Domain_Services\Response\Domain\Delete
- * @see \Automattic\Domain_Services\Event\Domain\Delete\Success
- * @see \Automattic\Domain_Services\Event\Domain\Delete\Fail
+ * @see \Automattic\Domain_Services_Client\Response\Domain\Delete
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Delete\Success
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Delete\Fail
  */
 class Delete implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Serialize_Trait;

--- a/lib/command/domain/info.php
+++ b/lib/command/domain/info.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command\Domain;
+namespace Automattic\Domain_Services_Client\Command\Domain;
 
-use Automattic\Domain_Services\{Command, Entity};
+use Automattic\Domain_Services_Client\{Command, Entity};
 
 /**
  * Retrieves information about a domain that is registered with the reseller.
@@ -26,7 +26,7 @@ use Automattic\Domain_Services\{Command, Entity};
  * - This command retrieves information about a domain that is registered on the reseller's account.
  * - If the domain is not registered on the reseller's account an error is returned.
  *
- * @see \Automattic\Domain_Services\Response\Domain\Info
+ * @see \Automattic\Domain_Services_Client\Response\Domain\Info
  */
 class Info implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Serialize_Trait;

--- a/lib/command/domain/register.php
+++ b/lib/command/domain/register.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command\Domain;
+namespace Automattic\Domain_Services_Client\Command\Domain;
 
-use Automattic\Domain_Services\{Command, Entity, Exception};
+use Automattic\Domain_Services_Client\{Command, Entity, Exception};
 
 /**
  * Register a new a domain.
@@ -84,9 +84,9 @@ use Automattic\Domain_Services\{Command, Entity, Exception};
  * }
  * ```
  *
- * @see     \Automattic\Domain_Services\Event\Domain\Register\Fail
- * @see     \Automattic\Domain_Services\Event\Domain\Register\Success
- * @see     \Automattic\Domain_Services\Response\Domain\Register
+ * @see     \Automattic\Domain_Services_Client\Event\Domain\Register\Fail
+ * @see     \Automattic\Domain_Services_Client\Event\Domain\Register\Success
+ * @see     \Automattic\Domain_Services_Client\Response\Domain\Register
  */
 class Register implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Serialize_Trait;

--- a/lib/command/domain/renew.php
+++ b/lib/command/domain/renew.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command\Domain;
+namespace Automattic\Domain_Services_Client\Command\Domain;
 
-use Automattic\Domain_Services\{Command, Entity};
+use Automattic\Domain_Services_Client\{Command, Entity};
 
 /**
  * Renews a domain
@@ -50,9 +50,9 @@ use Automattic\Domain_Services\{Command, Entity};
  * }
  * ```
  *
- * @see \Automattic\Domain_Services\Response\Domain\Renew
- * @see \Automattic\Domain_Services\Event\Domain\Renew\Success
- * @see \Automattic\Domain_Services\Event\Domain\Renew\Fail
+ * @see \Automattic\Domain_Services_Client\Response\Domain\Renew
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Renew\Success
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Renew\Fail
  */
 class Renew implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Serialize_Trait;

--- a/lib/command/domain/restore.php
+++ b/lib/command/domain/restore.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command\Domain;
+namespace Automattic\Domain_Services_Client\Command\Domain;
 
-use Automattic\Domain_Services\{Command, Entity};
+use Automattic\Domain_Services_Client\{Command, Entity};
 
 /**
  * Restores (redeems) a domain that is currently in the redemption period.
@@ -41,9 +41,9 @@ use Automattic\Domain_Services\{Command, Entity};
  * }
  * ```
  *
- * @see     \Automattic\Domain_Services\Event\Domain\Restore\Fail
- * @see     \Automattic\Domain_Services\Event\Domain\Restore\Success
- * @see     \Automattic\Domain_Services\Response\Domain\Restore
+ * @see     \Automattic\Domain_Services_Client\Event\Domain\Restore\Fail
+ * @see     \Automattic\Domain_Services_Client\Event\Domain\Restore\Success
+ * @see     \Automattic\Domain_Services_Client\Response\Domain\Restore
  */
 class Restore implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Serialize_Trait;

--- a/lib/command/domain/set/contacts.php
+++ b/lib/command/domain/set/contacts.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command\Domain\Set;
+namespace Automattic\Domain_Services_Client\Command\Domain\Set;
 
-use Automattic\Domain_Services\{Command, Entity, Exception};
+use Automattic\Domain_Services_Client\{Command, Entity, Exception};
 
 /**
  * Updates domain contacts
@@ -48,7 +48,7 @@ use Automattic\Domain_Services\{Command, Entity, Exception};
  * }
  * ```
  *
- * @see \Automattic\Domain_Services\Response\Domain\Set\Contacts
+ * @see \Automattic\Domain_Services_Client\Response\Domain\Set\Contacts
  * @see Entity\Contact_Id
  * @see Entity\Contact_Information
  * @see Entity\Domain_Contacts

--- a/lib/command/domain/set/nameservers.php
+++ b/lib/command/domain/set/nameservers.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command\Domain\Set;
+namespace Automattic\Domain_Services_Client\Command\Domain\Set;
 
-use Automattic\Domain_Services\{Command, Entity};
+use Automattic\Domain_Services_Client\{Command, Entity};
 
 /**
  * Sets name servers for the specified domain
@@ -46,9 +46,9 @@ use Automattic\Domain_Services\{Command, Entity};
  * }
  * ```
  *
- * @see \Automattic\Domain_Services\Response\Domain\Set\Nameservers
- * @see \Automattic\Domain_Services\Event\Domain\Set\Nameservers\Success
- * @see \Automattic\Domain_Services\Event\Domain\Set\Nameservers\Fail
+ * @see \Automattic\Domain_Services_Client\Response\Domain\Set\Nameservers
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Set\Nameservers\Success
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Set\Nameservers\Fail
  */
 class Nameservers implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Serialize_Trait;

--- a/lib/command/domain/set/privacy.php
+++ b/lib/command/domain/set/privacy.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command\Domain\Set;
+namespace Automattic\Domain_Services_Client\Command\Domain\Set;
 
-use Automattic\Domain_Services\{Command, Entity};
+use Automattic\Domain_Services_Client\{Command, Entity};
 
 /**
  * Sets the privacy option that determines what contact information is shown in WHOIS.
@@ -38,9 +38,9 @@ use Automattic\Domain_Services\{Command, Entity};
  * }
  * ```
  *
- * @see \Automattic\Domain_Services\Event\Domain\Set\Privacy\Fail
- * @see \Automattic\Domain_Services\Event\Domain\Set\Privacy\Success
- * @see \Automattic\Domain_Services\Response\Domain\Set\Privacy
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Set\Privacy\Fail
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Set\Privacy\Success
+ * @see \Automattic\Domain_Services_Client\Response\Domain\Set\Privacy
  */
 class Privacy implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Serialize_Trait;

--- a/lib/command/domain/set/transferlock.php
+++ b/lib/command/domain/set/transferlock.php
@@ -16,16 +16,16 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command\Domain\Set;
+namespace Automattic\Domain_Services_Client\Command\Domain\Set;
 
-use Automattic\Domain_Services\{Command, Entity};
+use Automattic\Domain_Services_Client\{Command, Entity};
 
 /**
  * Enables/Disables the transfer lock
  *
  * This commands requests either enabling or disabling the transfer lock on a specific domain.
  *
- * @see \Automattic\Domain_Services\Response\Domain\Set\Transferlock
+ * @see \Automattic\Domain_Services_Client\Response\Domain\Set\Transferlock
  */
 class Transferlock implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Trait;

--- a/lib/command/domain/suggestions.php
+++ b/lib/command/domain/suggestions.php
@@ -16,14 +16,14 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command\Domain;
+namespace Automattic\Domain_Services_Client\Command\Domain;
 
-use Automattic\Domain_Services\{Command};
+use Automattic\Domain_Services_Client\{Command};
 
 /**
  * Retrieves a list of domain name suggestions based on a query string
  *
- * @see \Automattic\Domain_Services\Response\Domain\Suggestions
+ * @see \Automattic\Domain_Services_Client\Response\Domain\Suggestions
  */
 class Suggestions implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Serialize_Trait;

--- a/lib/command/event/ack.php
+++ b/lib/command/event/ack.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command\Event;
+namespace Automattic\Domain_Services_Client\Command\Event;
 
-use Automattic\Domain_Services\{Command};
+use Automattic\Domain_Services_Client\{Command};
 
 /**
  * Acknowledge an event
@@ -27,8 +27,8 @@ use Automattic\Domain_Services\{Command};
  *  - IDs can be fetched using the `Event\Enumerate` command.
  *  - This command executes synchronously on the server.
  *
- * @see \Automattic\Domain_Services\Response\Event\Ack
- * @see \Automattic\Domain_Services\Response\Event\Enumerate
+ * @see \Automattic\Domain_Services_Client\Response\Event\Ack
+ * @see \Automattic\Domain_Services_Client\Response\Event\Enumerate
  */
 class Ack implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Serialize_Trait;

--- a/lib/command/event/details.php
+++ b/lib/command/event/details.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command\Event;
+namespace Automattic\Domain_Services_Client\Command\Event;
 
-use Automattic\Domain_Services\{Command};
+use Automattic\Domain_Services_Client\{Command};
 
 /**
  * Requests details of an event
@@ -28,8 +28,8 @@ use Automattic\Domain_Services\{Command};
  *  - This command executes synchronously on the server.
  *  - The corresponding response object will include the details of an event.
  *
- * @see \Automattic\Domain_Services\Response\Event\Details
- * @see \Automattic\Domain_Services\Response\Event\Enumerate
+ * @see \Automattic\Domain_Services_Client\Response\Event\Details
+ * @see \Automattic\Domain_Services_Client\Response\Event\Enumerate
  */
 class Details implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Trait;

--- a/lib/command/event/enumerate.php
+++ b/lib/command/event/enumerate.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Command\Event;
+namespace Automattic\Domain_Services_Client\Command\Event;
 
-use Automattic\Domain_Services\{Command};
+use Automattic\Domain_Services_Client\{Command};
 
 /**
  * Requests a list of unacknowledged events
@@ -29,7 +29,7 @@ use Automattic\Domain_Services\{Command};
  * - This command executes synchronously on the server.
  * - The corresponding response object will include the list of events.
  *
- * @see \Automattic\Domain_Services\Response\Event\Enumerate
+ * @see \Automattic\Domain_Services_Client\Response\Event\Enumerate
  */
 class Enumerate implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Serialize_Trait;

--- a/lib/configuration.php
+++ b/lib/configuration.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services;
+namespace Automattic\Domain_Services_Client;
 
 class Configuration {
 	public const BOOLEAN_FORMAT_INT = 'int';

--- a/lib/entity/contact-disclosure.php
+++ b/lib/entity/contact-disclosure.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Entity;
+namespace Automattic\Domain_Services_Client\Entity;
 
-use Automattic\Domain_Services\{Exception};
+use Automattic\Domain_Services_Client\{Exception};
 
 /**
  * The list of domain contact fields to disclose in the Whois results

--- a/lib/entity/contact-id.php
+++ b/lib/entity/contact-id.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Entity;
+namespace Automattic\Domain_Services_Client\Entity;
 
-use Automattic\Domain_Services\{Exception};
+use Automattic\Domain_Services_Client\{Exception};
 
 /**
  * Represents a contact ID

--- a/lib/entity/contact-information.php
+++ b/lib/entity/contact-information.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Entity;
+namespace Automattic\Domain_Services_Client\Entity;
 
-use Automattic\Domain_Services\{Exception};
+use Automattic\Domain_Services_Client\{Exception};
 
 /**
  * The contact information for domain registrants.

--- a/lib/entity/contact-verification-data.php
+++ b/lib/entity/contact-verification-data.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Entity;
+namespace Automattic\Domain_Services_Client\Entity;
 
 class Contact_Verification_Data {
 	/**

--- a/lib/entity/dns-record-set.php
+++ b/lib/entity/dns-record-set.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Entity;
+namespace Automattic\Domain_Services_Client\Entity;
 
 /**
  * A set of DNS records that share the same name, type and TTL
@@ -135,10 +135,10 @@ class Dns_Record_Set {
 	/**
 	 * Constructs a Dns_Record_Set entity from an associative array containing a DNS record set
 	 *
-	 * @internal
 	 * @param array $data
 	 * @return static
-	 * @throws \Automattic\Domain_Services\Exception\Entity\Invalid_Value_Exception
+	 * @throws \Automattic\Domain_Services_Client\Exception\Entity\Invalid_Value_Exception
+	 *@internal
 	 */
 	public static function from_array( array $data ): self {
 		return new self(

--- a/lib/entity/dns-record-sets.php
+++ b/lib/entity/dns-record-sets.php
@@ -16,14 +16,14 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Entity;
+namespace Automattic\Domain_Services_Client\Entity;
 
-use Automattic\Domain_Services\Exception\Entity\Invalid_Value_Exception;
+use Automattic\Domain_Services_Client\Exception\Entity\Invalid_Value_Exception;
 
 /**
  * Set of sets of DNS records
  *
- * @see \Automattic\Domain_Services\Entity\Dns_Record_Set
+ * @see \Automattic\Domain_Services_Client\Entity\Dns_Record_Set
  */
 class Dns_Record_Sets implements \Iterator {
 	/**
@@ -81,12 +81,12 @@ class Dns_Record_Sets implements \Iterator {
 	/**
 	 * Constructs a DNS_Record_Sets entity from an array of DNS record set values
 	 *
-	 * @internal
 	 * @param array $dns_record_sets_data
 	 * @return static
 	 * @throws Invalid_Value_Exception
 	 *
-	 * @see \Automattic\Domain_Services\Entity\Dns_Record_Set
+	 * @internal
+	 * @see \Automattic\Domain_Services_Client\Entity\Dns_Record_Set
 	 */
 	public static function from_array( array $dns_record_sets_data ): self {
 		$dns_record_sets = new self();

--- a/lib/entity/dns-record-type.php
+++ b/lib/entity/dns-record-type.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Entity;
+namespace Automattic\Domain_Services_Client\Entity;
 
-use Automattic\Domain_Services\{Exception};
+use Automattic\Domain_Services_Client\{Exception};
 
 class Dns_Record_Type {
 	public const A = 'A';

--- a/lib/entity/dns-records.php
+++ b/lib/entity/dns-records.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Entity;
+namespace Automattic\Domain_Services_Client\Entity;
 
-use Automattic\Domain_Services\{Command, Exception};
+use Automattic\Domain_Services_Client\{Command, Exception};
 
 /**
  * Set of DNS records associated with a specific domain
@@ -86,12 +86,12 @@ class Dns_Records {
 	/**
 	 * Constructs a Dns_Records entity from an array containing sets of DNS records
 	 *
-	 * @internal
 	 * @param array $dns_records_data
 	 * @return static
 	 * @throws Exception\Entity\Invalid_Value_Exception
 	 *
-	 * @see \Automattic\Domain_Services\Entity\Dns_Record_Sets
+	 * @internal
+	 * @see \Automattic\Domain_Services_Client\Entity\Dns_Record_Sets
 	 */
 	public static function from_array( array $dns_records_data ): self {
 		$domain_name = new Domain_Name( $dns_records_data[ Command\Command_Interface::KEY_DOMAIN ] );

--- a/lib/entity/domain-contact.php
+++ b/lib/entity/domain-contact.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Entity;
+namespace Automattic\Domain_Services_Client\Entity;
 
-use Automattic\Domain_Services\{Command, Exception};
+use Automattic\Domain_Services_Client\{Command, Exception};
 
 /**
  * Represents a domain contact

--- a/lib/entity/domain-contacts.php
+++ b/lib/entity/domain-contacts.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Entity;
+namespace Automattic\Domain_Services_Client\Entity;
 
-use Automattic\Domain_Services\{Exception};
+use Automattic\Domain_Services_Client\{Exception};
 
 /**
  * Represents all contact types for a domain name

--- a/lib/entity/domain-name.php
+++ b/lib/entity/domain-name.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Entity;
+namespace Automattic\Domain_Services_Client\Entity;
 
 class Domain_Name {
 	private string $name;

--- a/lib/entity/domain-names.php
+++ b/lib/entity/domain-names.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Entity;
+namespace Automattic\Domain_Services_Client\Entity;
 
 class Domain_Names {
 	/**

--- a/lib/entity/domain-suggestion.php
+++ b/lib/entity/domain-suggestion.php
@@ -16,14 +16,14 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Entity;
+namespace Automattic\Domain_Services_Client\Entity;
 
 /**
  * Domain name suggestion
  *
  * Used in the `Domain\Suggestions` response.
  *
- * @see \Automattic\Domain_Services\Response\Domain\Suggestions
+ * @see \Automattic\Domain_Services_Client\Response\Domain\Suggestions
  */
 class Suggestion {
 	/**

--- a/lib/entity/domain-suggestions.php
+++ b/lib/entity/domain-suggestions.php
@@ -16,15 +16,15 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Entity;
+namespace Automattic\Domain_Services_Client\Entity;
 
 /**
  * List of Suggestion entities
  *
  * Used in the `Domain\Suggestions` response.
  *
- * @see \Automattic\Domain_Services\Entity\Suggestion
- * @see \Automattic\Domain_Services\Response\Domain\Suggestions
+ * @see \Automattic\Domain_Services_Client\Entity\Suggestion
+ * @see \Automattic\Domain_Services_Client\Response\Domain\Suggestions
  */
 class Suggestions {
 	/**

--- a/lib/entity/epp-status-code.php
+++ b/lib/entity/epp-status-code.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Entity;
+namespace Automattic\Domain_Services_Client\Entity;
 
-use Automattic\Domain_Services\{Exception};
+use Automattic\Domain_Services_Client\{Exception};
 
 /**
  * A class that represents an EPP status code

--- a/lib/entity/epp-status-codes.php
+++ b/lib/entity/epp-status-codes.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Entity;
+namespace Automattic\Domain_Services_Client\Entity;
 
 class Epp_Status_Codes implements \Iterator {
 	/**

--- a/lib/entity/nameservers.php
+++ b/lib/entity/nameservers.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Entity;
+namespace Automattic\Domain_Services_Client\Entity;
 
-use Automattic\Domain_Services\{Exception};
+use Automattic\Domain_Services_Client\{Exception};
 
 /**
  * Set of name servers

--- a/lib/entity/whois-privacy.php
+++ b/lib/entity/whois-privacy.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Entity;
+namespace Automattic\Domain_Services_Client\Entity;
 
-use Automattic\Domain_Services\{Exception};
+use Automattic\Domain_Services_Client\{Exception};
 
 /**
  * Define a valid privacy setting to be used for a domain

--- a/lib/event/contact/verification/notify.php
+++ b/lib/event/contact/verification/notify.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Contact\Verification;
+namespace Automattic\Domain_Services_Client\Event\Contact\Verification;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services_Client\{Event};
 
 /**
  * Verification notify event

--- a/lib/event/contact/verification/request.php
+++ b/lib/event/contact/verification/request.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Contact\Verification;
+namespace Automattic\Domain_Services_Client\Event\Contact\Verification;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services_Client\{Event};
 
 /**
  * Verification request event

--- a/lib/event/data-trait.php
+++ b/lib/event/data-trait.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event;
+namespace Automattic\Domain_Services_Client\Event;
 
-use Automattic\Domain_Services\Helper;
+use Automattic\Domain_Services_Client\Helper;
 
 /**
  * A trait that defines data access methods common to all event classes.

--- a/lib/event/domain/delete/fail.php
+++ b/lib/event/domain/delete/fail.php
@@ -16,16 +16,16 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Delete;
+namespace Automattic\Domain_Services_Client\Event\Domain\Delete;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services_Client\{Event};
 
 /**
  * Domain deletion failed event
  *
  * This event is generated when a domain delete operation fails at the server.
  *
- * @see \Automattic\Domain_Services\Command\Domain\Delete
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Delete
  */
 class Fail implements Event\Event_Interface {
 	use Event\Data_Trait;

--- a/lib/event/domain/delete/success.php
+++ b/lib/event/domain/delete/success.php
@@ -16,16 +16,16 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Delete;
+namespace Automattic\Domain_Services_Client\Event\Domain\Delete;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services_Client\{Event};
 
 /**
  * Domain deletion success event
  *
  * This event is generated when a domain delete operation succeeds at the server.
  *
- * @see \Automattic\Domain_Services\Command\Domain\Delete
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Delete
  */
 class Success implements Event\Event_Interface {
 	use Event\Data_Trait;

--- a/lib/event/domain/notification/argp.php
+++ b/lib/event/domain/notification/argp.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Notification;
+namespace Automattic\Domain_Services_Client\Event\Domain\Notification;
 
-use Automattic\Domain_Services\{Helper, Event};
+use Automattic\Domain_Services_Client\{Helper, Event};
 
 /**
  * Domain entered the Auto-Renew Grace Period (ARGP) event
@@ -30,7 +30,7 @@ use Automattic\Domain_Services\{Helper, Event};
  * - This event may contain an `argp_end_date` property which can be retrieved using the `get_argp_end_date` method
  *     - That is the date until which the domain is in ARGP
  *
- * @see \Automattic\Domain_Services\Event\Domain\Notification\Redemption
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Notification\Redemption
  */
 class Argp implements Event\Event_Interface {
 	use Event\Data_Trait;

--- a/lib/event/domain/notification/auction.php
+++ b/lib/event/domain/notification/auction.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Notification;
+namespace Automattic\Domain_Services_Client\Event\Domain\Notification;
 
-use Automattic\Domain_Services\{Helper, Event};
+use Automattic\Domain_Services_Client\{Helper, Event};
 
 /**
  * Domain entered auction phase event
@@ -37,7 +37,7 @@ use Automattic\Domain_Services\{Helper, Event};
  *     - `auction_status_end_date` - date until which the domain is in the current auction phase, can be retrieved using
  *       the `get_auction_status_end_date` method
  *
- * @see \Automattic\Domain_Services\Event\Domain\Notification\Redemption
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Notification\Redemption
  */
 class Auction implements Event\Event_Interface {
 	use Event\Data_Trait;

--- a/lib/event/domain/notification/pending-delete.php
+++ b/lib/event/domain/notification/pending-delete.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Notification;
+namespace Automattic\Domain_Services_Client\Event\Domain\Notification;
 
-use Automattic\Domain_Services\{Event, Helper};
+use Automattic\Domain_Services_Client\{Event, Helper};
 
 /**
  * Domain expired event

--- a/lib/event/domain/notification/redemption.php
+++ b/lib/event/domain/notification/redemption.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Notification;
+namespace Automattic\Domain_Services_Client\Event\Domain\Notification;
 
-use Automattic\Domain_Services\{Helper, Event};
+use Automattic\Domain_Services_Client\{Helper, Event};
 
 /**
  * Domain entered redemption period event
@@ -33,7 +33,7 @@ use Automattic\Domain_Services\{Helper, Event};
  *   method
  *     - That is the date until which the domain is in redemption
  *
- * @see \Automattic\Domain_Services\Event\Domain\Notification\Argp
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Notification\Argp
  */
 class Redemption implements Event\Event_Interface {
 	use Event\Data_Trait;

--- a/lib/event/domain/notification/suspended.php
+++ b/lib/event/domain/notification/suspended.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Notification;
+namespace Automattic\Domain_Services_Client\Event\Domain\Notification;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services_Client\{Event};
 
 /**
  * Domain suspended event
@@ -28,7 +28,7 @@ use Automattic\Domain_Services\{Event};
  * - This event contains an `info` property with information about the reason why the domain was suspended, if available
  *     - It can be retrieved with the `get_info` method
  *
- * @see \Automattic\Domain_Services\Event\Domain\Notification\Verified
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Notification\Verified
  */
 class Suspended implements Event\Event_Interface {
 	use Event\Data_Trait;

--- a/lib/event/domain/notification/verified.php
+++ b/lib/event/domain/notification/verified.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Notification;
+namespace Automattic\Domain_Services_Client\Event\Domain\Notification;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services_Client\{Event};
 
 /**
  * Domain verified event
@@ -28,7 +28,7 @@ use Automattic\Domain_Services\{Event};
  * - This event contains an `info` property with information about the reason why the domain was verified, if available
  *     - It can be retrieved with the `get_info` method
  *
- * @see \Automattic\Domain_Services\Event\Domain\Notification\Suspended
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Notification\Suspended
  */
 class Verified implements Event\Event_Interface {
 	use Event\Data_Trait;

--- a/lib/event/domain/register/fail.php
+++ b/lib/event/domain/register/fail.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Register;
+namespace Automattic\Domain_Services_Client\Event\Domain\Register;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services_Client\{Event};
 
 /**
  * Failure event for a `Domain\Register` command
@@ -26,7 +26,7 @@ use Automattic\Domain_Services\{Event};
  * This event is sent when a register operation fails. There may be more information about the cause of the failure in
  * the event data.
  *
- * @see \Automattic\Domain_Services\Command\Domain\Register
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Register
  */
 class Fail implements Event\Event_Interface {
 	use Event\Data_Trait;

--- a/lib/event/domain/register/success.php
+++ b/lib/event/domain/register/success.php
@@ -16,16 +16,16 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Register;
+namespace Automattic\Domain_Services_Client\Event\Domain\Register;
 
-use Automattic\Domain_Services\{Entity, Event, Exception, Helper};
+use Automattic\Domain_Services_Client\{Entity, Event, Exception, Helper};
 
 /**
  * Success event for a `Domain\Register` command.
  *
  * This event is sent when a register operation succeeds.
  *
- * @see \Automattic\Domain_Services\Command\Domain\Register
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Register
  */
 class Success implements Event\Event_Interface {
 	use Event\Data_Trait;

--- a/lib/event/domain/renew/fail.php
+++ b/lib/event/domain/renew/fail.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Renew;
+namespace Automattic\Domain_Services_Client\Event\Domain\Renew;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services_Client\{Event};
 
 /**
  * Domain failed to renew event
@@ -26,7 +26,7 @@ use Automattic\Domain_Services\{Event};
  * - This event is generated when a domain renewal operation fails at the server
  * - There might be more information about the cause of the failure in the event data
  *
- * @see \Automattic\Domain_Services\Command\Domain\Renew
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Renew
  */
 class Fail implements Event\Event_Interface {
 	use Event\Data_Trait;

--- a/lib/event/domain/renew/success.php
+++ b/lib/event/domain/renew/success.php
@@ -16,16 +16,16 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Renew;
+namespace Automattic\Domain_Services_Client\Event\Domain\Renew;
 
-use Automattic\Domain_Services\{Entity, Event, Helper, Exception};
+use Automattic\Domain_Services_Client\{Entity, Event, Helper, Exception};
 
 /**
  * Domain renewed successfully event
  *
  * This event is generated when a domain renewal operation has completed successfully at the server.
  *
- * @see \Automattic\Domain_Services\Command\Domain\Renew
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Renew
  */
 class Success implements Event\Event_Interface {
 	use Event\Data_Trait;

--- a/lib/event/domain/restore/fail.php
+++ b/lib/event/domain/restore/fail.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Restore;
+namespace Automattic\Domain_Services_Client\Event\Domain\Restore;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services_Client\{Event};
 
 /**
  * Failure event for a `Domain\Restore` command
@@ -26,7 +26,7 @@ use Automattic\Domain_Services\{Event};
  * This event is sent when a restore operation fails. There may be more information about the cause of the failure in
  * the event data.
  *
- * @see \Automattic\Domain_Services\Command\Domain\Restore
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Restore
  */
 class Fail implements Event\Event_Interface {
 	use Event\Data_Trait;

--- a/lib/event/domain/restore/success.php
+++ b/lib/event/domain/restore/success.php
@@ -16,16 +16,16 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Restore;
+namespace Automattic\Domain_Services_Client\Event\Domain\Restore;
 
-use Automattic\Domain_Services\{Entity, Event, Helper, Exception};
+use Automattic\Domain_Services_Client\{Entity, Event, Helper, Exception};
 
 /**
  * Success event for a `Domain\Restore` command.
  *
  * This event is sent when a restore operation succeeds.
  *
- * @see \Automattic\Domain_Services\Command\Domain\Restore
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Restore
  */
 class Success implements Event\Event_Interface {
 	use Event\Data_Trait;

--- a/lib/event/domain/set/contacts/fail.php
+++ b/lib/event/domain/set/contacts/fail.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Set\Contacts;
+namespace Automattic\Domain_Services_Client\Event\Domain\Set\Contacts;
 
-use Automattic\Domain_Services\{Command, Event};
+use Automattic\Domain_Services_Client\{Command, Event};
 
 /**
  * Event representing a Domain\Set\Contacts command failure

--- a/lib/event/domain/set/contacts/success.php
+++ b/lib/event/domain/set/contacts/success.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Set\Contacts;
+namespace Automattic\Domain_Services_Client\Event\Domain\Set\Contacts;
 
-use Automattic\Domain_Services\{Command, Entity, Event, Exception};
+use Automattic\Domain_Services_Client\{Command, Entity, Event, Exception};
 
 /**
  * Event representing a Domain\Set\Contacts command success

--- a/lib/event/domain/set/nameservers/fail.php
+++ b/lib/event/domain/set/nameservers/fail.php
@@ -16,16 +16,16 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Set\Nameservers;
+namespace Automattic\Domain_Services_Client\Event\Domain\Set\Nameservers;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services_Client\{Event};
 
 /**
  * Set name servers failure event
  *
  * This event is generated when a name server update fails at the server.
  *
- * @see \Automattic\Domain_Services\Command\Domain\Set\Nameservers
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Set\Nameservers
  */
 class Fail implements Event\Event_Interface {
 	use Event\Data_Trait;

--- a/lib/event/domain/set/nameservers/success.php
+++ b/lib/event/domain/set/nameservers/success.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Set\Nameservers;
+namespace Automattic\Domain_Services_Client\Event\Domain\Set\Nameservers;
 
-use Automattic\Domain_Services\{Entity, Event, Exception};
+use Automattic\Domain_Services_Client\{Entity, Event, Exception};
 
 /**
  * Set name servers success event
@@ -26,7 +26,7 @@ use Automattic\Domain_Services\{Entity, Event, Exception};
  * - This event is generated when a name server update succeeds at the server
  * - Contains a `name_servers` property with the name servers that were set at the registry
  *
- * @see \Automattic\Domain_Services\Command\Domain\Set\Nameservers
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Set\Nameservers
  */
 class Success implements Event\Event_Interface {
 	use Event\Data_Trait;

--- a/lib/event/domain/set/privacy/fail.php
+++ b/lib/event/domain/set/privacy/fail.php
@@ -16,16 +16,16 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Set\Privacy;
+namespace Automattic\Domain_Services_Client\Event\Domain\Set\Privacy;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services_Client\{Event};
 
 /**
  * Fail event for a `Domain\Set\Privacy command
  *
  * This event is generated when a privacy setting update fails at the server.
  *
- * @see \Automattic\Domain_Services\Command\Domain\Set\Privacy
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Set\Privacy
  */
 class Fail implements Event\Event_Interface {
 	use Event\Data_Trait;

--- a/lib/event/domain/set/privacy/success.php
+++ b/lib/event/domain/set/privacy/success.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Set\Privacy;
+namespace Automattic\Domain_Services_Client\Event\Domain\Set\Privacy;
 
-use Automattic\Domain_Services\{Entity, Event, Exception};
+use Automattic\Domain_Services_Client\{Entity, Event, Exception};
 
 /**
  * Success event for a `Domain\Set\Privacy command
@@ -26,7 +26,7 @@ use Automattic\Domain_Services\{Entity, Event, Exception};
  * - This event is generated when a privacy setting update succeeds at the server.
  * - Contains a `privacy_setting` property with the privacy option that was set at the registry
  *
- * @see \Automattic\Domain_Services\Command\Domain\Set\Privacy
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Set\Privacy
  */
 class Success implements Event\Event_Interface {
 	use Event\Data_Trait;

--- a/lib/event/domain/set/transferlock/fail.php
+++ b/lib/event/domain/set/transferlock/fail.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Set\Transferlock;
+namespace Automattic\Domain_Services_Client\Event\Domain\Set\Transferlock;
 
-use Automattic\Domain_Services\{Command, Event};
+use Automattic\Domain_Services_Client\{Command, Event};
 
 /**
  * Fail event for Domain\Set\TransferLock command

--- a/lib/event/domain/set/transferlock/success.php
+++ b/lib/event/domain/set/transferlock/success.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Set\Transferlock;
+namespace Automattic\Domain_Services_Client\Event\Domain\Set\Transferlock;
 
-use Automattic\Domain_Services\{Event, Command};
+use Automattic\Domain_Services_Client\{Event, Command};
 
 /**
  * Success event for Domain\Set\TransferLock command

--- a/lib/event/domain/transfer/in/fail.php
+++ b/lib/event/domain/transfer/in/fail.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Transfer\In;
+namespace Automattic\Domain_Services_Client\Event\Domain\Transfer\In;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services_Client\{Event};
 
 /**
  * Inbound domain transfer failure event

--- a/lib/event/domain/transfer/in/pending.php
+++ b/lib/event/domain/transfer/in/pending.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Transfer\In;
+namespace Automattic\Domain_Services_Client\Event\Domain\Transfer\In;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services_Client\{Event};
 
 /**
  * Inbound domain transfer start event

--- a/lib/event/domain/transfer/in/success.php
+++ b/lib/event/domain/transfer/in/success.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Transfer\In;
+namespace Automattic\Domain_Services_Client\Event\Domain\Transfer\In;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services_Client\{Event};
 
 /**
  * Inbound domain transfer success event

--- a/lib/event/domain/transfer/out/fail.php
+++ b/lib/event/domain/transfer/out/fail.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Transfer\Out;
+namespace Automattic\Domain_Services_Client\Event\Domain\Transfer\Out;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services_Client\{Event};
 
 /**
  * Outbound domain transfer failure event

--- a/lib/event/domain/transfer/out/pending.php
+++ b/lib/event/domain/transfer/out/pending.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Transfer\Out;
+namespace Automattic\Domain_Services_Client\Event\Domain\Transfer\Out;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services_Client\{Event};
 
 /**
  * Outbound domain transfer start event

--- a/lib/event/domain/transfer/out/success.php
+++ b/lib/event/domain/transfer/out/success.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event\Domain\Transfer\Out;
+namespace Automattic\Domain_Services_Client\Event\Domain\Transfer\Out;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services_Client\{Event};
 
 /**
  * Outbound domain transfer success event

--- a/lib/event/error-trait.php
+++ b/lib/event/error-trait.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event;
+namespace Automattic\Domain_Services_Client\Event;
 
 /**
  * A trait that specifies methods common to all error event classes.

--- a/lib/event/event-interface.php
+++ b/lib/event/event-interface.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event;
+namespace Automattic\Domain_Services_Client\Event;
 
 /**
  * An interface used by all event classes.

--- a/lib/event/factory.php
+++ b/lib/event/factory.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event;
+namespace Automattic\Domain_Services_Client\Event;
 
-use Automattic\Domain_Services\{Exception};
+use Automattic\Domain_Services_Client\{Exception};
 
 /**
  * @internal

--- a/lib/event/object-type-contact-trait.php
+++ b/lib/event/object-type-contact-trait.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event;
+namespace Automattic\Domain_Services_Client\Event;
 
-use Automattic\Domain_Services\{Entity};
+use Automattic\Domain_Services_Client\{Entity};
 
 trait Object_Type_Contact_Trait {
 	final public function get_contact_id(): Entity\Contact_Id {

--- a/lib/event/object-type-domain-trait.php
+++ b/lib/event/object-type-domain-trait.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event;
+namespace Automattic\Domain_Services_Client\Event;
 
-use Automattic\Domain_Services\{Entity};
+use Automattic\Domain_Services_Client\{Entity};
 
 trait Object_Type_Domain_Trait {
 	final public function get_domain(): Entity\Domain_Name {

--- a/lib/event/transfer-trait.php
+++ b/lib/event/transfer-trait.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Event;
+namespace Automattic\Domain_Services_Client\Event;
 
-use Automattic\Domain_Services\{Helper};
+use Automattic\Domain_Services_Client\{Helper};
 
 trait Transfer_Trait {
 	final public function get_current_registrar(): ?string {

--- a/lib/exception/command/invalid-format-exception.php
+++ b/lib/exception/command/invalid-format-exception.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Exception\Command;
+namespace Automattic\Domain_Services_Client\Exception\Command;
 
-use Automattic\Domain_Services\{Exception, Response};
+use Automattic\Domain_Services_Client\{Exception, Response};
 
 class Invalid_Format_Exception extends Exception\Domain_Services_Exception {
 	/**

--- a/lib/exception/command/missing-option-exception.php
+++ b/lib/exception/command/missing-option-exception.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Exception\Command;
+namespace Automattic\Domain_Services_Client\Exception\Command;
 
-use Automattic\Domain_Services\{Exception, Response};
+use Automattic\Domain_Services_Client\{Exception, Response};
 
 class Missing_Option_Exception extends Exception\Domain_Services_Exception {
 	/**

--- a/lib/exception/domain-services-exception.php
+++ b/lib/exception/domain-services-exception.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Exception;
+namespace Automattic\Domain_Services_Client\Exception;
 
-use Automattic\Domain_Services\{Response};
+use Automattic\Domain_Services_Client\{Response};
 
 class Domain_Services_Exception extends \Exception {
 	private array $data;

--- a/lib/exception/entity/invalid-value-exception.php
+++ b/lib/exception/entity/invalid-value-exception.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Exception\Entity;
+namespace Automattic\Domain_Services_Client\Exception\Entity;
 
-use Automattic\Domain_Services\{Exception, Response};
+use Automattic\Domain_Services_Client\{Exception, Response};
 
 class Invalid_Value_Exception extends Exception\Domain_Services_Exception {
 	/**

--- a/lib/exception/event/invalid-event-name.php
+++ b/lib/exception/event/invalid-event-name.php
@@ -16,6 +16,6 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Exception\Event;
+namespace Automattic\Domain_Services_Client\Exception\Event;
 
 class Invalid_Event_Name extends \Exception { }

--- a/lib/helper/date-time.php
+++ b/lib/helper/date-time.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Helper;
+namespace Automattic\Domain_Services_Client\Helper;
 
 use DateTime;
 use DateTimeImmutable;

--- a/lib/request/factory.php
+++ b/lib/request/factory.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Request;
+namespace Automattic\Domain_Services_Client\Request;
 
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;

--- a/lib/response/code.php
+++ b/lib/response/code.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response;
+namespace Automattic\Domain_Services_Client\Response;
 
 class Code {
 	public const SUCCESS = 200;

--- a/lib/response/contact/details.php
+++ b/lib/response/contact/details.php
@@ -16,14 +16,14 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response\Contact;
+namespace Automattic\Domain_Services_Client\Response\Contact;
 
-use Automattic\Domain_Services\{Entity, Response, Exception};
+use Automattic\Domain_Services_Client\{Entity, Response, Exception};
 
 /**
  * Response containing the Contact_Information associated with a Contact_Id
  *
- * @see \Automattic\Domain_Services\Command\Contact\Details
+ * @see \Automattic\Domain_Services_Client\Command\Contact\Details
  */
 class Details implements Response\Response_Interface {
 	use Response\Data_Trait;

--- a/lib/response/data-trait.php
+++ b/lib/response/data-trait.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response;
+namespace Automattic\Domain_Services_Client\Response;
 
 trait Data_Trait {
 	private array $data;

--- a/lib/response/dns/get.php
+++ b/lib/response/dns/get.php
@@ -16,16 +16,16 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response\Dns;
+namespace Automattic\Domain_Services_Client\Response\Dns;
 
-use Automattic\Domain_Services\{Entity, Exception, Response};
+use Automattic\Domain_Services_Client\{Entity, Exception, Response};
 
 /**
  * Response of a Dns\Get command
  *
  * Contains all DNS records associated with a domain, which can be accessed using the `get_dns_records` method.
  *
- * @see \Automattic\Domain_Services\Command\Dns\Set
+ * @see \Automattic\Domain_Services_Client\Command\Dns\Set
  */
 class Get implements Response\Response_Interface {
 	use Response\Data_Trait;

--- a/lib/response/dns/set.php
+++ b/lib/response/dns/set.php
@@ -16,16 +16,16 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response\Dns;
+namespace Automattic\Domain_Services_Client\Response\Dns;
 
-use Automattic\Domain_Services\{Entity, Exception, Response};
+use Automattic\Domain_Services_Client\{Entity, Exception, Response};
 
 /**
  * Response of a Dns\Set command
  *
  * Contains the domain name, the newly added records and the deleted records.
  *
- * @see \Automattic\Domain_Services\Command\Dns\Set
+ * @see \Automattic\Domain_Services_Client\Command\Dns\Set
  */
 class Set implements Response\Response_Interface {
 	use Response\Data_Trait;

--- a/lib/response/domain/check.php
+++ b/lib/response/domain/check.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response\Domain;
+namespace Automattic\Domain_Services_Client\Response\Domain;
 
-use Automattic\Domain_Services\Response;
+use Automattic\Domain_Services_Client\Response;
 
 /**
  * Response of the `Domain\Check` command

--- a/lib/response/domain/delete.php
+++ b/lib/response/domain/delete.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response\Domain;
+namespace Automattic\Domain_Services_Client\Response\Domain;
 
-use Automattic\Domain_Services\Response;
+use Automattic\Domain_Services_Client\Response;
 
 /**
  * Response of a Domain\Delete command
@@ -28,9 +28,9 @@ use Automattic\Domain_Services\Response;
  *     - The `Domain\Delete\Success` and `Domain\Delete\Fail` events will indicate whether the operation was successful
  *       or not
  *
- * @see \Automattic\Domain_Services\Command\Domain\Delete
- * @see \Automattic\Domain_Services\Event\Domain\Delete\Success
- * @see \Automattic\Domain_Services\Event\Domain\Delete\Fail
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Delete
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Delete\Success
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Delete\Fail
  */
 class Delete implements Response\Response_Interface {
 	use Response\Data_Trait;

--- a/lib/response/domain/info.php
+++ b/lib/response/domain/info.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response\Domain;
+namespace Automattic\Domain_Services_Client\Response\Domain;
 
-use Automattic\Domain_Services\{Entity, Response, Helper};
+use Automattic\Domain_Services_Client\{Entity, Response, Helper};
 
 /**
  * Response of a `Domain\Info` command
@@ -88,7 +88,7 @@ class Info implements Response\Response_Interface {
 	 * Gets the current EPP status codes for the domain
 	 *
 	 * @return Entity\Epp_Status_Codes
-	 * @throws \Automattic\Domain_Services\Exception\Entity\Invalid_Value_Exception
+	 * @throws \Automattic\Domain_Services_Client\Exception\Entity\Invalid_Value_Exception
 	 */
 	public function get_domain_status(): Entity\Epp_Status_Codes {
 		$epp_statuses_data = $this->get_data_by_key( 'data.domain_status' );
@@ -103,7 +103,7 @@ class Info implements Response\Response_Interface {
 	 * Gets the name servers set at the registry for this domain
 	 *
 	 * @return Entity\Nameservers|null
-	 * @throws \Automattic\Domain_Services\Exception\Entity\Invalid_Value_Exception
+	 * @throws \Automattic\Domain_Services_Client\Exception\Entity\Invalid_Value_Exception
 	 */
 	public function get_name_servers(): ?Entity\Nameservers {
 		$nameservers_data = $this->get_data_by_key( 'data.name_servers' );

--- a/lib/response/domain/register.php
+++ b/lib/response/domain/register.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response\Domain;
+namespace Automattic\Domain_Services_Client\Response\Domain;
 
 /**
  * Response of a Domain\Register command
@@ -24,12 +24,12 @@ namespace Automattic\Domain_Services\Response\Domain;
  * Since the command runs asynchronously on the server, success response indicates that request has been queued, not
  * completed.
  *
- * @see \Automattic\Domain_Services\Command\Domain\Register
- * @see \Automattic\Domain_Services\Event\Domain\Register\Fail
- * @see \Automattic\Domain_Services\Event\Domain\Register\Success
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Register
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Register\Fail
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Register\Success
  */
 
-use Automattic\Domain_Services\{Response};
+use Automattic\Domain_Services_Client\{Response};
 
 class Register implements Response\Response_Interface {
 	use Response\Data_Trait;

--- a/lib/response/domain/renew.php
+++ b/lib/response/domain/renew.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response\Domain;
+namespace Automattic\Domain_Services_Client\Response\Domain;
 
-use Automattic\Domain_Services\{Response};
+use Automattic\Domain_Services_Client\{Response};
 
 /**
  * Response of a Domain\Renew command
@@ -28,9 +28,9 @@ use Automattic\Domain_Services\{Response};
  *     - The `Domain\Renew\Success` and `Domain\Renew\Fail` events will indicate whether the operation was successful
  *     or not
  *
- * @see \Automattic\Domain_Services\Command\Domain\Renew
- * @see \Automattic\Domain_Services\Event\Domain\Renew\Fail
- * @see \Automattic\Domain_Services\Event\Domain\Renew\Success
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Renew
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Renew\Fail
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Renew\Success
  */
 class Renew implements Response\Response_Interface {
 	use Response\Data_Trait;

--- a/lib/response/domain/restore.php
+++ b/lib/response/domain/restore.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response\Domain;
+namespace Automattic\Domain_Services_Client\Response\Domain;
 
-use Automattic\Domain_Services\Response;
+use Automattic\Domain_Services_Client\Response;
 
 /**
  * Response of a `Domain\Restore` command
@@ -26,9 +26,9 @@ use Automattic\Domain_Services\Response;
  * - The restore operation runs asynchronously on the server.
  * - A success response indicates that the restore request is queued, not completed.
  *
- * @see \Automattic\Domain_Services\Command\Domain\Restore
- * @see \Automattic\Domain_Services\Event\Domain\Restore\Fail
- * @see \Automattic\Domain_Services\Event\Domain\Restore\Success
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Restore
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Restore\Fail
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Restore\Success
  */
 class Restore implements Response\Response_Interface {
 	use Response\Data_Trait;

--- a/lib/response/domain/set/contacts.php
+++ b/lib/response/domain/set/contacts.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response\Domain\Set;
+namespace Automattic\Domain_Services_Client\Response\Domain\Set;
 
-use Automattic\Domain_Services\{Event, Response, Command};
+use Automattic\Domain_Services_Client\{Event, Response, Command};
 
 /**
  * Response for Domain\Set\Contacts command

--- a/lib/response/domain/set/nameservers.php
+++ b/lib/response/domain/set/nameservers.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response\Domain\Set;
+namespace Automattic\Domain_Services_Client\Response\Domain\Set;
 
-use Automattic\Domain_Services\Response;
+use Automattic\Domain_Services_Client\Response;
 
 /**
  * Response of a Domain\Set\Nameservers command
@@ -28,9 +28,9 @@ use Automattic\Domain_Services\Response;
  *     - The `Domain\Set\Nameservers\Success` and `Domain\Set\Nameservers\Fail` events will indicate whether the
  *       operation was successful or not
  *
- * @see \Automattic\Domain_Services\Command\Domain\Set\Nameservers
- * @see \Automattic\Domain_Services\Event\Domain\Set\Nameservers\Success
- * @see \Automattic\Domain_Services\Event\Domain\Set\Nameservers\Fail
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Set\Nameservers
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Set\Nameservers\Success
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Set\Nameservers\Fail
  */
 class Nameservers implements Response\Response_Interface {
 	use Response\Data_Trait;

--- a/lib/response/domain/set/privacy.php
+++ b/lib/response/domain/set/privacy.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response\Domain\Set;
+namespace Automattic\Domain_Services_Client\Response\Domain\Set;
 
-use Automattic\Domain_Services\{Response};
+use Automattic\Domain_Services_Client\{Response};
 
 /**
  * Response of a Domain\Set\Privacy command
@@ -26,9 +26,9 @@ use Automattic\Domain_Services\{Response};
  * Since the command runs asynchronously on the server, success response indicates that request has been queued, not
  * completed.
  *
- * @see \Automattic\Domain_Services\Command\Domain\Set\Privacy
- * @see \Automattic\Domain_Services\Event\Domain\Set\Privacy\Success
- * @see \Automattic\Domain_Services\Event\Domain\Set\Privacy\Fail
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Set\Privacy
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Set\Privacy\Success
+ * @see \Automattic\Domain_Services_Client\Event\Domain\Set\Privacy\Fail
  */
 class Privacy implements Response\Response_Interface {
 	use Response\Data_Trait;

--- a/lib/response/domain/set/transferlock.php
+++ b/lib/response/domain/set/transferlock.php
@@ -16,14 +16,14 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response\Domain\Set;
+namespace Automattic\Domain_Services_Client\Response\Domain\Set;
 
-use Automattic\Domain_Services\Response;
+use Automattic\Domain_Services_Client\Response;
 
 /**
  * Response of a Transferlock\Set command.
  *
- * @see \Automattic\Domain_Services\Command\Domain\Set\Transferlock
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Set\Transferlock
  */
 class Transferlock implements Response\Response_Interface {
 	use Response\Data_Trait;

--- a/lib/response/domain/suggestions.php
+++ b/lib/response/domain/suggestions.php
@@ -16,14 +16,14 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response\Domain;
+namespace Automattic\Domain_Services_Client\Response\Domain;
 
-use Automattic\Domain_Services\{Entity, Response};
+use Automattic\Domain_Services_Client\{Entity, Response};
 
 /**
  * Response of a Domain_Suggestions command
  *
- * @see \Automattic\Domain_Services\Command\Domain\Suggestions
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Suggestions
  */
 class Suggestions implements Response\Response_Interface {
 	use Response\Data_Trait;

--- a/lib/response/event-aware.php
+++ b/lib/response/event-aware.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response;
+namespace Automattic\Domain_Services_Client\Response;
 
-use Automattic\Domain_Services\{Event};
+use Automattic\Domain_Services_Client\{Event};
 
 /**
  * @internal

--- a/lib/response/event/ack.php
+++ b/lib/response/event/ack.php
@@ -16,14 +16,14 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response\Event;
+namespace Automattic\Domain_Services_Client\Response\Event;
 
-use Automattic\Domain_Services\{Response};
+use Automattic\Domain_Services_Client\{Response};
 
 /**
  * Response of an `Event\Ack` command.
  *
- * @see \Automattic\Domain_Services\Command\Event\Ack
+ * @see \Automattic\Domain_Services_Client\Command\Event\Ack
  */
 class Ack implements Response\Response_Interface {
 	use Response\Data_Trait;

--- a/lib/response/event/details.php
+++ b/lib/response/event/details.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response\Event;
+namespace Automattic\Domain_Services_Client\Response\Event;
 
-use Automattic\Domain_Services\{Event, Exception\Event\Invalid_Event_Name, Response};
+use Automattic\Domain_Services_Client\{Event, Exception\Event\Invalid_Event_Name, Response};
 
 /**
  * Response of an Event_Details command.
@@ -26,7 +26,7 @@ use Automattic\Domain_Services\{Event, Exception\Event\Invalid_Event_Name, Respo
  * This is the response returned from a successful execution of Event_Details command. The event can be retrieved using
  * get_event() method.
  *
- * @see \Automattic\Domain_Services\Command\Event\Details
+ * @see \Automattic\Domain_Services_Client\Command\Event\Details
  */
 class Details implements Response\Response_Interface {
 	use Response\Data_Trait;

--- a/lib/response/event/enumerate.php
+++ b/lib/response/event/enumerate.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response\Event;
+namespace Automattic\Domain_Services_Client\Response\Event;
 
-use Automattic\Domain_Services\{Event, Exception, Response};
+use Automattic\Domain_Services_Client\{Event, Exception, Response};
 
 /**
  * Response of Event\Enumerate command

--- a/lib/response/exception/error.php
+++ b/lib/response/exception/error.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response\Exception;
+namespace Automattic\Domain_Services_Client\Response\Exception;
 
-use Automattic\Domain_Services\{Response};
+use Automattic\Domain_Services_Client\{Response};
 
 class Error implements Response\Response_Interface {
 	use Response\Data_Trait;

--- a/lib/response/factory.php
+++ b/lib/response/factory.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response;
+namespace Automattic\Domain_Services_Client\Response;
 
-use Automattic\Domain_Services\{Command, Event, Exception};
+use Automattic\Domain_Services_Client\{Command, Event, Exception};
 
 /**
  * @internal

--- a/lib/response/response-interface.php
+++ b/lib/response/response-interface.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Response;
+namespace Automattic\Domain_Services_Client\Response;
 
 interface Response_Interface {
 }

--- a/test/api/api-test.php
+++ b/test/api/api-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Api;
+namespace Automattic\Domain_Services_Client\Test\Api;
 
-use Automattic\Domain_Services\{Api, Command, Configuration, Entity, Response, Request, Test};
+use Automattic\Domain_Services_Client\{Api, Command, Configuration, Entity, Response, Request, Test};
 use Http\Factory\Guzzle\RequestFactory;
 use Http\Factory\Guzzle\StreamFactory;
 use Psr\Http\Client\ClientExceptionInterface;
@@ -46,7 +46,7 @@ class ApiTest extends Test\Lib\Domain_Services_Client_Test_Case {
 					'+1.7577468269',
 					null
 				),
-				new Entity\Contact_Disclosure( \Automattic\Domain_Services\Entity\Contact_Disclosure::NONE )
+				new Entity\Contact_Disclosure( \Automattic\Domain_Services_Client\Entity\Contact_Disclosure::NONE )
 			)
 		);
 

--- a/test/command/contact-details-test.php
+++ b/test/command/contact-details-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Command;
+namespace Automattic\Domain_Services_Client\Test\Command;
 
-use Automattic\Domain_Services\{Command, Entity, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Test};
 
 class Contact_Details_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_command_instance_success(): void {

--- a/test/command/dns-get-test.php
+++ b/test/command/dns-get-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Command;
+namespace Automattic\Domain_Services_Client\Test\Command;
 
-use Automattic\Domain_Services\{Command, Entity, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Test};
 
 class Dns_Get_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_command_instance_success(): void {

--- a/test/command/dns-set-test.php
+++ b/test/command/dns-set-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Command;
+namespace Automattic\Domain_Services_Client\Test\Command;
 
-use Automattic\Domain_Services\{Command, Entity, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Test};
 
 class Dns_Set_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 

--- a/test/command/domain-check-test.php
+++ b/test/command/domain-check-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Command;
+namespace Automattic\Domain_Services_Client\Test\Command;
 
-use Automattic\Domain_Services\{Command, Entity, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Test};
 
 class Domain_Check_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 

--- a/test/command/domain-delete-test.php
+++ b/test/command/domain-delete-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Command;
+namespace Automattic\Domain_Services_Client\Test\Command;
 
-use Automattic\Domain_Services\{Command, Entity, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Test};
 
 class Domain_Delete_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 

--- a/test/command/domain-info-test.php
+++ b/test/command/domain-info-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Command;
+namespace Automattic\Domain_Services_Client\Test\Command;
 
-use Automattic\Domain_Services\{Command, Entity, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Test};
 
 class Domain_Info_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 

--- a/test/command/domain-register-test.php
+++ b/test/command/domain-register-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Command;
+namespace Automattic\Domain_Services_Client\Test\Command;
 
-use Automattic\Domain_Services\{Command, Entity, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Test};
 
 class Domain_Register_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 

--- a/test/command/domain-renew-test.php
+++ b/test/command/domain-renew-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Command;
+namespace Automattic\Domain_Services_Client\Test\Command;
 
-use Automattic\Domain_Services\{Command, Entity, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Test};
 
 class Domain_Renew_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 

--- a/test/command/domain-restore-test.php
+++ b/test/command/domain-restore-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Command;
+namespace Automattic\Domain_Services_Client\Test\Command;
 
-use Automattic\Domain_Services\{Command, Entity, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Test};
 
 class Domain_Restore_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 

--- a/test/command/domain-set-contacts-test.php
+++ b/test/command/domain-set-contacts-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Command;
+namespace Automattic\Domain_Services_Client\Test\Command;
 
-use Automattic\Domain_Services\{Command, Entity, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Test};
 
 class Domain_Set_Contacts_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 

--- a/test/command/domain-set-nameservers-test.php
+++ b/test/command/domain-set-nameservers-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Command;
+namespace Automattic\Domain_Services_Client\Test\Command;
 
-use Automattic\Domain_Services\{Command, Entity, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Test};
 
 class Domain_Set_Nameservers_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 

--- a/test/command/domain-set-privacy-test.php
+++ b/test/command/domain-set-privacy-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Command;
+namespace Automattic\Domain_Services_Client\Test\Command;
 
-use Automattic\Domain_Services\{Command, Entity, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Test};
 
 class Domain_Set_Privacy_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 

--- a/test/command/domain-set-transferlock-test.php
+++ b/test/command/domain-set-transferlock-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Command;
+namespace Automattic\Domain_Services_Client\Test\Command;
 
-use Automattic\Domain_Services\{Command, Entity, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Test};
 
 class Domain_Set_Transferlock_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 

--- a/test/command/domain-suggestions-test.php
+++ b/test/command/domain-suggestions-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Command;
+namespace Automattic\Domain_Services_Client\Test\Command;
 
-use Automattic\Domain_Services\{Command, Test};
+use Automattic\Domain_Services_Client\{Command, Test};
 
 class Domain_Suggestions_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 

--- a/test/command/event-ack-test.php
+++ b/test/command/event-ack-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Command;
+namespace Automattic\Domain_Services_Client\Test\Command;
 
-use Automattic\Domain_Services\{Command, Test};
+use Automattic\Domain_Services_Client\{Command, Test};
 
 class Event_Ack_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 

--- a/test/command/event-details-test.php
+++ b/test/command/event-details-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Command;
+namespace Automattic\Domain_Services_Client\Test\Command;
 
-use Automattic\Domain_Services\{Command, Test};
+use Automattic\Domain_Services_Client\{Command, Test};
 
 class Event_Details_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 

--- a/test/command/event-enumerate-test.php
+++ b/test/command/event-enumerate-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Command;
+namespace Automattic\Domain_Services_Client\Test\Command;
 
-use Automattic\Domain_Services\{Command, Test};
+use Automattic\Domain_Services_Client\{Command, Test};
 
 class Event_Enumerate_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 

--- a/test/entity/contact-disclosure-test.php
+++ b/test/entity/contact-disclosure-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Entity;
+namespace Automattic\Domain_Services_Client\Test\Entity;
 
-use Automattic\Domain_Services\{Entity, Exception, Response, Test};
+use Automattic\Domain_Services_Client\{Entity, Exception, Response, Test};
 
 class Contact_Disclosure_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_entity_instance_success_disclose_all(): void {

--- a/test/entity/contact-id-test.php
+++ b/test/entity/contact-id-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Entity;
+namespace Automattic\Domain_Services_Client\Test\Entity;
 
-use Automattic\Domain_Services\{Entity, Exception, Response, Test};
+use Automattic\Domain_Services_Client\{Entity, Exception, Response, Test};
 
 class Contact_Id_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_entity_instance_success(): void {

--- a/test/entity/contact-information-test.php
+++ b/test/entity/contact-information-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Entity;
+namespace Automattic\Domain_Services_Client\Test\Entity;
 
-use Automattic\Domain_Services\{Entity, Exception, Response, Test};
+use Automattic\Domain_Services_Client\{Entity, Exception, Response, Test};
 
 class Contact_Information_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_entity_instance_success_construct_entity(): void {

--- a/test/entity/contact-verification-data-test.php
+++ b/test/entity/contact-verification-data-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Entity;
+namespace Automattic\Domain_Services_Client\Test\Entity;
 
-use Automattic\Domain_Services\{Entity, Test};
+use Automattic\Domain_Services_Client\{Entity, Test};
 
 class Contact_Verification_Data_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_entity_instance_success(): void {

--- a/test/entity/dns-record-set-test.php
+++ b/test/entity/dns-record-set-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Entity;
+namespace Automattic\Domain_Services_Client\Test\Entity;
 
-use Automattic\Domain_Services\{Entity, Test};
+use Automattic\Domain_Services_Client\{Entity, Test};
 
 class Dns_Record_Set_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_entity_instance_success(): void {

--- a/test/entity/dns-record-sets-test.php
+++ b/test/entity/dns-record-sets-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Entity;
+namespace Automattic\Domain_Services_Client\Test\Entity;
 
-use Automattic\Domain_Services\{Entity, Test};
+use Automattic\Domain_Services_Client\{Entity, Test};
 
 class Dns_Record_Sets_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_entity_instance_success(): void {

--- a/test/entity/dns-record-type-test.php
+++ b/test/entity/dns-record-type-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Entity;
+namespace Automattic\Domain_Services_Client\Test\Entity;
 
-use Automattic\Domain_Services\{Entity, Exception, Response, Test};
+use Automattic\Domain_Services_Client\{Entity, Exception, Response, Test};
 
 class Dns_Record_Type_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public const VALID_RECORD_TYPES = [

--- a/test/entity/dns-records-test.php
+++ b/test/entity/dns-records-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Entity;
+namespace Automattic\Domain_Services_Client\Test\Entity;
 
-use Automattic\Domain_Services\{Entity, Test};
+use Automattic\Domain_Services_Client\{Entity, Test};
 
 class Dns_Records_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_entity_instance_success(): void {

--- a/test/entity/domain-contact-test.php
+++ b/test/entity/domain-contact-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Entity;
+namespace Automattic\Domain_Services_Client\Test\Entity;
 
-use Automattic\Domain_Services\{Entity, Test};
+use Automattic\Domain_Services_Client\{Entity, Test};
 
 class Domain_Contact_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_entity_instance_contact_info_success(): void {

--- a/test/entity/domain-contacts-test.php
+++ b/test/entity/domain-contacts-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Entity;
+namespace Automattic\Domain_Services_Client\Test\Entity;
 
-use Automattic\Domain_Services\{Entity, Exception, Response, Test};
+use Automattic\Domain_Services_Client\{Entity, Exception, Response, Test};
 
 class Domain_Contacts_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	private const CONTACT_TYPES = [

--- a/test/entity/domain-suggestions-test.php
+++ b/test/entity/domain-suggestions-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Entity;
+namespace Automattic\Domain_Services_Client\Test\Entity;
 
-use Automattic\Domain_Services\{Entity, Test};
+use Automattic\Domain_Services_Client\{Entity, Test};
 
 class Domain_Suggestions_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_entity_instance_success(): void {

--- a/test/entity/epp-status-code-test.php
+++ b/test/entity/epp-status-code-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Entity;
+namespace Automattic\Domain_Services_Client\Test\Entity;
 
-use Automattic\Domain_Services\{Entity, Exception, Response, Test};
+use Automattic\Domain_Services_Client\{Entity, Exception, Response, Test};
 
 class EPP_Status_Code_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	/**

--- a/test/entity/epp-status-codes-test.php
+++ b/test/entity/epp-status-codes-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Entity;
+namespace Automattic\Domain_Services_Client\Test\Entity;
 
-use Automattic\Domain_Services\{Entity, Test};
+use Automattic\Domain_Services_Client\{Entity, Test};
 
 class Epp_Status_Codes_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_entity_instance_success(): void {

--- a/test/entity/nameservers-test.php
+++ b/test/entity/nameservers-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Entity;
+namespace Automattic\Domain_Services_Client\Test\Entity;
 
-use Automattic\Domain_Services\{Entity, Exception, Response, Test};
+use Automattic\Domain_Services_Client\{Entity, Exception, Response, Test};
 
 class Nameservers_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_entity_instance_success(): void {

--- a/test/event/contact-verification-notify-test.php
+++ b/test/event/contact-verification-notify-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Event, Response, Test};
 
 class Contact_Verification_Notify_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/contact-verification-request-test.php
+++ b/test/event/contact-verification-request-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Event, Response, Test};
 
 class Contact_Verification_Request_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-delete-fail-test.php
+++ b/test/event/domain-delete-fail-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Event, Response, Test};
 
 class Domain_Delete_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-delete-success-test.php
+++ b/test/event/domain-delete-success-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Event, Response, Test};
 
 class Domain_Delete_Success_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-notification-argp-test.php
+++ b/test/event/domain-notification-argp-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Helper, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Helper, Event, Response, Test};
 
 class Domain_Notification_Argp_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-notification-auction-test.php
+++ b/test/event/domain-notification-auction-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Helper, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Helper, Event, Response, Test};
 
 class Domain_Notification_Auction_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-notification-pending-delete-test.php
+++ b/test/event/domain-notification-pending-delete-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Helper, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Helper, Event, Response, Test};
 
 class Domain_Notification_Pending_Delete_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-notification-redemption-test.php
+++ b/test/event/domain-notification-redemption-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Helper, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Helper, Event, Response, Test};
 
 class Domain_Notification_Redemption_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-notification-suspended-test.php
+++ b/test/event/domain-notification-suspended-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Event, Response, Test};
 
 class Domain_Notification_Suspended_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-notification-verified-test.php
+++ b/test/event/domain-notification-verified-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Event, Response, Test};
 
 class Domain_Notification_Verified_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-register-fail-test.php
+++ b/test/event/domain-register-fail-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Event, Response, Test};
 
 class Domain_Register_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-register-success-test.php
+++ b/test/event/domain-register-success-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Helper, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Helper, Event, Response, Test};
 
 class Domain_Register_Success_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-renew-fail-test.php
+++ b/test/event/domain-renew-fail-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Event, Response, Test};
 
 class Domain_Renew_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-renew-success-test.php
+++ b/test/event/domain-renew-success-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Helper, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Helper, Event, Response, Test};
 
 class Domain_Renew_Success_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-restore-fail-test.php
+++ b/test/event/domain-restore-fail-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Event, Response, Test};
 
 class Domain_Restore_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-restore-success-test.php
+++ b/test/event/domain-restore-success-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Helper, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Helper, Event, Response, Test};
 
 class Domain_Restore_Success_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-set-contacts-fail-test.php
+++ b/test/event/domain-set-contacts-fail-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Event, Response, Test};
 
 class Domain_Set_Contacts_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-set-contacts-success-test.php
+++ b/test/event/domain-set-contacts-success-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Event, Response, Test};
 
 class Domain_Set_Contacts_Success_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-set-nameservers-fail-test.php
+++ b/test/event/domain-set-nameservers-fail-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Event, Response, Test};
 
 class Domain_Set_Nameservers_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-set-nameservers-success-test.php
+++ b/test/event/domain-set-nameservers-success-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Event, Response, Test};
 
 class Domain_Set_Nameservers_Success_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-set-privacy-fail-test.php
+++ b/test/event/domain-set-privacy-fail-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Event, Response, Test};
 
 class Domain_Set_Privacy_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-set-privacy-success-test.php
+++ b/test/event/domain-set-privacy-success-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Event, Response, Test};
 
 class Domain_Set_Privacy_Success_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-set-transferlock-fail-test.php
+++ b/test/event/domain-set-transferlock-fail-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Event, Response, Test};
 
 class Domain_Set_Transferlock_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-set-transferlock-success-test.php
+++ b/test/event/domain-set-transferlock-success-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Event, Response, Test};
 
 class Domain_Set_Transferlock_Success_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-transfer-in-fail-test.php
+++ b/test/event/domain-transfer-in-fail-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Helper, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Helper, Event, Response, Test};
 
 class Domain_Transfer_In_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-transfer-in-pending-test.php
+++ b/test/event/domain-transfer-in-pending-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Helper, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Helper, Event, Response, Test};
 
 class Domain_Transfer_In_Pending_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-transfer-in-success-test.php
+++ b/test/event/domain-transfer-in-success-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Helper, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Helper, Event, Response, Test};
 
 class Domain_Transfer_In_Success_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-transfer-out-fail-test.php
+++ b/test/event/domain-transfer-out-fail-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Helper, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Helper, Event, Response, Test};
 
 class Domain_Transfer_Out_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-transfer-out-pending-test.php
+++ b/test/event/domain-transfer-out-pending-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Helper, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Helper, Event, Response, Test};
 
 class Domain_Transfer_Out_Pending_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/event/domain-transfer-out-success-test.php
+++ b/test/event/domain-transfer-out-success-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Event;
+namespace Automattic\Domain_Services_Client\Test\Event;
 
-use Automattic\Domain_Services\{Command, Helper, Event, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Helper, Event, Response, Test};
 
 class Domain_Transfer_Out_Success_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {

--- a/test/lib/domain-services-client-test-case.php
+++ b/test/lib/domain-services-client-test-case.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Lib;
+namespace Automattic\Domain_Services_Client\Test\Lib;
 
-use Automattic\Domain_Services\{Response};
+use Automattic\Domain_Services_Client\{Response};
 
 class Domain_Services_Client_Test_Case extends \PHPUnit\Framework\TestCase {
 	protected Response\Factory $response_factory;

--- a/test/lib/mock/psr/http/message/client.php
+++ b/test/lib/mock/psr/http/message/client.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Lib\Mock\Psr\Http\Message;
+namespace Automattic\Domain_Services_Client\Test\Lib\Mock\Psr\Http\Message;
 
 class Client implements \Psr\Http\Client\ClientInterface {
 	private Response $mock_response;

--- a/test/lib/mock/psr/http/message/response.php
+++ b/test/lib/mock/psr/http/message/response.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Lib\Mock\Psr\Http\Message;
+namespace Automattic\Domain_Services_Client\Test\Lib\Mock\Psr\Http\Message;
 
 /**
  * Representation of an outgoing, server-side response.

--- a/test/lib/mock/psr/http/message/stream.php
+++ b/test/lib/mock/psr/http/message/stream.php
@@ -16,7 +16,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Lib\Mock\Psr\Http\Message;
+namespace Automattic\Domain_Services_Client\Test\Lib\Mock\Psr\Http\Message;
 
 /**
  * Describes a data stream.

--- a/test/response/contact-details-test.php
+++ b/test/response/contact-details-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Response;
+namespace Automattic\Domain_Services_Client\Test\Response;
 
-use Automattic\Domain_Services\{Command, Entity, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Response, Test};
 
 class Contact_Details_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_response_factory_success(): void {

--- a/test/response/dns-get-test.php
+++ b/test/response/dns-get-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Response;
+namespace Automattic\Domain_Services_Client\Test\Response;
 
-use Automattic\Domain_Services\{Command, Entity, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Response, Test};
 
 class Dns_Get_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_response_factory_success(): void {

--- a/test/response/dns-set-test.php
+++ b/test/response/dns-set-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Response;
+namespace Automattic\Domain_Services_Client\Test\Response;
 
-use Automattic\Domain_Services\{Command, Entity, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Response, Test};
 
 class Dns_Set_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_response_factory_success(): void {

--- a/test/response/domain-check-test.php
+++ b/test/response/domain-check-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Response;
+namespace Automattic\Domain_Services_Client\Test\Response;
 
-use Automattic\Domain_Services\{Command, Entity, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Response, Test};
 
 class Domain_Check_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_response_factory_success(): void {

--- a/test/response/domain-delete-test.php
+++ b/test/response/domain-delete-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Response;
+namespace Automattic\Domain_Services_Client\Test\Response;
 
-use Automattic\Domain_Services\{Command, Entity, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Response, Test};
 
 class Domain_Delete_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_response_factory_success(): void {

--- a/test/response/domain-info-test.php
+++ b/test/response/domain-info-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Response;
+namespace Automattic\Domain_Services_Client\Test\Response;
 
-use Automattic\Domain_Services\{Command, Entity, Response, Test, Helper};
+use Automattic\Domain_Services_Client\{Command, Entity, Response, Test, Helper};
 
 class Domain_Info_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_response_factory_success(): void {

--- a/test/response/domain-register-test.php
+++ b/test/response/domain-register-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Response;
+namespace Automattic\Domain_Services_Client\Test\Response;
 
-use Automattic\Domain_Services\{Command, Entity, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Response, Test};
 
 class Domain_Register_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_response_factory_success(): void {

--- a/test/response/domain-renew-test.php
+++ b/test/response/domain-renew-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Response;
+namespace Automattic\Domain_Services_Client\Test\Response;
 
-use Automattic\Domain_Services\{Command, Entity, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Response, Test};
 
 class Domain_Renew_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_response_factory_success(): void {

--- a/test/response/domain-restore-test.php
+++ b/test/response/domain-restore-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Response;
+namespace Automattic\Domain_Services_Client\Test\Response;
 
-use Automattic\Domain_Services\{Command, Entity, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Response, Test};
 
 class Domain_Restore_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_response_factory_success(): void {

--- a/test/response/domain-set-contacts-test.php
+++ b/test/response/domain-set-contacts-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Response;
+namespace Automattic\Domain_Services_Client\Test\Response;
 
-use Automattic\Domain_Services\{Command, Entity, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Response, Test};
 
 class Domain_Set_Contacts_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_response_factory_success(): void {

--- a/test/response/domain-set-nameservers-test.php
+++ b/test/response/domain-set-nameservers-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Response;
+namespace Automattic\Domain_Services_Client\Test\Response;
 
-use Automattic\Domain_Services\{Command, Entity, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Response, Test};
 
 class Domain_Set_Nameservers_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_response_factory_success(): void {

--- a/test/response/domain-set-privacy-test.php
+++ b/test/response/domain-set-privacy-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Response;
+namespace Automattic\Domain_Services_Client\Test\Response;
 
-use Automattic\Domain_Services\{Command, Entity, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Response, Test};
 
 class Domain_Set_Privacy_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_response_factory_success(): void {

--- a/test/response/domain-set-transferlock-test.php
+++ b/test/response/domain-set-transferlock-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Response;
+namespace Automattic\Domain_Services_Client\Test\Response;
 
-use Automattic\Domain_Services\{Command, Entity, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Entity, Response, Test};
 
 class Domain_Set_Transferlock_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_response_factory_success(): void {

--- a/test/response/domain-suggestions-test.php
+++ b/test/response/domain-suggestions-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Response;
+namespace Automattic\Domain_Services_Client\Test\Response;
 
-use Automattic\Domain_Services\{Command, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Response, Test};
 
 class Domain_Suggestions_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_response_factory_success(): void {

--- a/test/response/event-ack-test.php
+++ b/test/response/event-ack-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Response;
+namespace Automattic\Domain_Services_Client\Test\Response;
 
-use Automattic\Domain_Services\{Command, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Response, Test};
 
 class Event_Ack_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_response_factory_success(): void {

--- a/test/response/event-details-test.php
+++ b/test/response/event-details-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Response;
+namespace Automattic\Domain_Services_Client\Test\Response;
 
-use Automattic\Domain_Services\{Command, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Response, Test};
 
 class Event_Details_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_response_factory_success(): void {

--- a/test/response/events-enumerate-test.php
+++ b/test/response/events-enumerate-test.php
@@ -16,9 +16,9 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services\Test\Response;
+namespace Automattic\Domain_Services_Client\Test\Response;
 
-use Automattic\Domain_Services\{Command, Helper, Response, Test};
+use Automattic\Domain_Services_Client\{Command, Helper, Response, Test};
 
 class Event_Enumerate_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_response_factory_success(): void {


### PR DESCRIPTION
This PR updates the base namespace of the library from `Automattic\Domain_Services` to `Automattic\Domain_Services_Api`. This makes sense as it's the same name as the package and also makes some client-server integration testing simpler.

### Testing

Make sure everything is still working by running unit tests:
```
composer install
./vendor/bin/phpunit -c ./test/phpunit.xml
```