### PR TITLE
Update `Event\Enumerate` docblocks

### DIFF
--- a/lib/command/event/enumerate.php
+++ b/lib/command/event/enumerate.php
@@ -27,7 +27,8 @@ use Automattic\Domain_Services_Client\{Command};
  * array of events in ascending order by age (oldest to newest). The maximum number of events returned in the response,
  * can be set using the `$limit` property for this command. The limit defaults to 50 if none is set.
  * - This command executes synchronously on the server.
- * - The corresponding response object will include the list of events.
+ * - The corresponding response object will include the list of events and the total number of non acknowledged events
+ *   for the reseller.
  *
  * @see \Automattic\Domain_Services_Client\Response\Event\Enumerate
  */

--- a/lib/command/event/enumerate.php
+++ b/lib/command/event/enumerate.php
@@ -27,7 +27,7 @@ use Automattic\Domain_Services_Client\{Command};
  * array of events in ascending order by age (oldest to newest). The maximum number of events returned in the response,
  * can be set using the `$limit` property for this command. The limit defaults to 50 if none is set.
  * - This command executes synchronously on the server.
- * - The corresponding response object will include the list of events and the total number of non acknowledged events
+ * - The corresponding response object will include the list of events and the total number of unacknowledged events
  *   for the reseller.
  *
  * @see \Automattic\Domain_Services_Client\Response\Event\Enumerate

--- a/lib/response/event/enumerate.php
+++ b/lib/response/event/enumerate.php
@@ -38,7 +38,7 @@ class Enumerate implements Response\Response_Interface {
 	private const REQUEST_PARAMS = 'data.request_params';
 
 	/**
-	 * Gets the total number of events returned
+	 * Gets the total number of non acknowledged events that exist for the reseller that called the command
 	 *
 	 * @return int
 	 */

--- a/lib/response/event/enumerate.php
+++ b/lib/response/event/enumerate.php
@@ -38,7 +38,7 @@ class Enumerate implements Response\Response_Interface {
 	private const REQUEST_PARAMS = 'data.request_params';
 
 	/**
-	 * Gets the total number of non acknowledged events that exist for the reseller that called the command
+	 * Gets the total number of unacknowledged events that exist for the reseller that called the command
 	 *
 	 * @return int
 	 */


### PR DESCRIPTION
This PR updates the docblocks for the `Event\Enumerate` command. The `total_count` property in the response now contains the total number of non acknowledged events that exist for the reseller that issued the command.

### Testing

- Code inspection