### PR TITLE
Standardize error_detail naming

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,4 +6,4 @@
 
 
 --------
-> This document was automatically generated from source code comments on 2023-02-07
+> This document was automatically generated from source code comments on 2023-02-15

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,4 +6,4 @@
 
 
 --------
-> This document was automatically generated from source code comments on 2023-02-02
+> This document was automatically generated from source code comments on 2023-02-07

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Contact-Verification-Notify.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Contact-Verification-Notify.md
@@ -18,8 +18,11 @@ This event indicates a change in the contact's status. It's usually generated wh
 * public [get_contact_id()](#method_get_contact_id)
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -152,27 +155,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -192,6 +189,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Contact-Verification-Request.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Contact-Verification-Request.md
@@ -19,8 +19,11 @@ This event indicates that a verification request was sent to the contact's email
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_email()](#method_get_email)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -171,27 +174,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -211,6 +208,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Data-Trait.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Data-Trait.md
@@ -13,8 +13,11 @@ Trait that defines data access methods common to all event classes.
 * public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -118,27 +121,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -158,6 +155,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Delete-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Delete-Fail.md
@@ -17,10 +17,13 @@ This event is generated when a domain delete operation fails at the server.
 * public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_error_detail()](#method_get_error_detail)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_errors()](#method_get_event_errors)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -130,25 +133,6 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_error_detail"></a>
-### get_error_detail
-
-```
-final public get_error_detail() : string
-```
-
-##### Summary
-
-Gets additional information about the reason for the error.
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_event_class"></a>
 ### get_event_class
 
@@ -168,27 +152,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -208,6 +186,100 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_errors"></a>
+### get_event_errors
+
+```
+final public get_event_errors() : array[]
+```
+
+##### Summary
+
+Gets additional information about the reason for the error.
+
+##### Description
+
+The format will be an array of arrays:
+[
+    [
+        &#039;description&#039; =&gt; &#039;A description of an error&#039;,
+        &#039;extra&#039; =&gt; [
+            &#039;extra_info_example_1&#039; =&gt; &#039;some additional information about this error&#039;,
+    ],
+    [
+        &#039;description&#039; =&gt; &#039;A description of another error&#039;,
+        &#039;extra&#039; =&gt; [
+            &#039;extra_info_example_2&#039; =&gt; &#039;some additional information about this error&#039;,
+            &#039;extra_info_example_3&#039; =&gt; &#039;even more additional information about this error&#039;,
+        ],
+    ],
+]
+
+##### Returns:
+
+```
+array[]
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Delete-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Delete-Fail.md
@@ -17,7 +17,7 @@ This event is generated when a domain delete operation fails at the server.
 * public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_error_reason()](#method_get_error_reason)
+* public [get_error_detail()](#method_get_error_detail)
 * public [get_event_class()](#method_get_event_class)
 * public [get_event_data()](#method_get_event_data)
 * public [get_event_date()](#method_get_event_date)
@@ -130,11 +130,11 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_error_reason"></a>
-### get_error_reason
+<a id="method_get_error_detail"></a>
+### get_error_detail
 
 ```
-final public get_error_reason() : string
+final public get_error_detail() : string
 ```
 
 ##### Summary

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Delete-Success.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Delete-Success.md
@@ -18,8 +18,11 @@ This event is generated when a domain delete operation succeeds at the server.
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -147,27 +150,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -187,6 +184,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Argp.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Argp.md
@@ -24,8 +24,11 @@ Domain entered the Auto-Renew Grace Period (ARGP) event
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -172,27 +175,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -212,6 +209,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Auction.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Auction.md
@@ -32,8 +32,11 @@ Domain entered auction phase event
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -199,27 +202,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -239,6 +236,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Pending-Delete.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Pending-Delete.md
@@ -20,8 +20,11 @@ Domain expired event
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -148,27 +151,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -188,6 +185,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Redemption.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Redemption.md
@@ -26,8 +26,11 @@ Domain entered redemption period event
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -156,27 +159,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -196,6 +193,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Suspended.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Suspended.md
@@ -21,8 +21,11 @@ Domain suspended event
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_info()](#method_get_info)
@@ -151,27 +154,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -191,6 +188,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Verified.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Verified.md
@@ -21,8 +21,11 @@ Domain verified event
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_info()](#method_get_info)
@@ -151,27 +154,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -191,6 +188,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Register-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Register-Fail.md
@@ -18,7 +18,7 @@ the event data.
 * public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_error_reason()](#method_get_error_reason)
+* public [get_error_detail()](#method_get_error_detail)
 * public [get_event_class()](#method_get_event_class)
 * public [get_event_data()](#method_get_event_data)
 * public [get_event_date()](#method_get_event_date)
@@ -131,11 +131,11 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_error_reason"></a>
-### get_error_reason
+<a id="method_get_error_detail"></a>
+### get_error_detail
 
 ```
-final public get_error_reason() : string
+final public get_error_detail() : string
 ```
 
 ##### Summary

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Register-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Register-Fail.md
@@ -18,10 +18,13 @@ the event data.
 * public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_error_detail()](#method_get_error_detail)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_errors()](#method_get_event_errors)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -131,25 +134,6 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_error_detail"></a>
-### get_error_detail
-
-```
-final public get_error_detail() : string
-```
-
-##### Summary
-
-Gets additional information about the reason for the error.
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_event_class"></a>
 ### get_event_class
 
@@ -169,27 +153,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -209,6 +187,100 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_errors"></a>
+### get_event_errors
+
+```
+final public get_event_errors() : array[]
+```
+
+##### Summary
+
+Gets additional information about the reason for the error.
+
+##### Description
+
+The format will be an array of arrays:
+[
+    [
+        &#039;description&#039; =&gt; &#039;A description of an error&#039;,
+        &#039;extra&#039; =&gt; [
+            &#039;extra_info_example_1&#039; =&gt; &#039;some additional information about this error&#039;,
+    ],
+    [
+        &#039;description&#039; =&gt; &#039;A description of another error&#039;,
+        &#039;extra&#039; =&gt; [
+            &#039;extra_info_example_2&#039; =&gt; &#039;some additional information about this error&#039;,
+            &#039;extra_info_example_3&#039; =&gt; &#039;even more additional information about this error&#039;,
+        ],
+    ],
+]
+
+##### Returns:
+
+```
+array[]
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Register-Success.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Register-Success.md
@@ -22,8 +22,11 @@ This event is sent when a register operation succeeds.
 * public [get_domain()](#method_get_domain)
 * public [get_domain_status()](#method_get_domain_status)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_expiration_date()](#method_get_expiration_date)
 * public [get_id()](#method_get_id)
@@ -248,27 +251,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -288,6 +285,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Renew-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Renew-Fail.md
@@ -18,10 +18,13 @@ Domain failed to renew event
 * public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_error_detail()](#method_get_error_detail)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_errors()](#method_get_event_errors)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -131,25 +134,6 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_error_detail"></a>
-### get_error_detail
-
-```
-final public get_error_detail() : string
-```
-
-##### Summary
-
-Gets additional information about the reason for the error.
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_event_class"></a>
 ### get_event_class
 
@@ -169,27 +153,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -209,6 +187,100 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_errors"></a>
+### get_event_errors
+
+```
+final public get_event_errors() : array[]
+```
+
+##### Summary
+
+Gets additional information about the reason for the error.
+
+##### Description
+
+The format will be an array of arrays:
+[
+    [
+        &#039;description&#039; =&gt; &#039;A description of an error&#039;,
+        &#039;extra&#039; =&gt; [
+            &#039;extra_info_example_1&#039; =&gt; &#039;some additional information about this error&#039;,
+    ],
+    [
+        &#039;description&#039; =&gt; &#039;A description of another error&#039;,
+        &#039;extra&#039; =&gt; [
+            &#039;extra_info_example_2&#039; =&gt; &#039;some additional information about this error&#039;,
+            &#039;extra_info_example_3&#039; =&gt; &#039;even more additional information about this error&#039;,
+        ],
+    ],
+]
+
+##### Returns:
+
+```
+array[]
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Renew-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Renew-Fail.md
@@ -18,7 +18,7 @@ Domain failed to renew event
 * public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_error_reason()](#method_get_error_reason)
+* public [get_error_detail()](#method_get_error_detail)
 * public [get_event_class()](#method_get_event_class)
 * public [get_event_data()](#method_get_event_data)
 * public [get_event_date()](#method_get_event_date)
@@ -131,11 +131,11 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_error_reason"></a>
-### get_error_reason
+<a id="method_get_error_detail"></a>
+### get_error_detail
 
 ```
-final public get_error_reason() : string
+final public get_error_detail() : string
 ```
 
 ##### Summary

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Renew-Success.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Renew-Success.md
@@ -19,8 +19,11 @@ This event is generated when a domain renewal operation has completed successful
 * public [get_domain()](#method_get_domain)
 * public [get_domain_status()](#method_get_domain_status)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_expiration_date()](#method_get_expiration_date)
 * public [get_id()](#method_get_id)
@@ -175,27 +178,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -215,6 +212,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Restore-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Restore-Fail.md
@@ -18,7 +18,7 @@ the event data.
 * public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_error_reason()](#method_get_error_reason)
+* public [get_error_detail()](#method_get_error_detail)
 * public [get_event_class()](#method_get_event_class)
 * public [get_event_data()](#method_get_event_data)
 * public [get_event_date()](#method_get_event_date)
@@ -131,11 +131,11 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_error_reason"></a>
-### get_error_reason
+<a id="method_get_error_detail"></a>
+### get_error_detail
 
 ```
-final public get_error_reason() : string
+final public get_error_detail() : string
 ```
 
 ##### Summary

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Restore-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Restore-Fail.md
@@ -18,10 +18,13 @@ the event data.
 * public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_error_detail()](#method_get_error_detail)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_errors()](#method_get_event_errors)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -131,25 +134,6 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_error_detail"></a>
-### get_error_detail
-
-```
-final public get_error_detail() : string
-```
-
-##### Summary
-
-Gets additional information about the reason for the error.
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_event_class"></a>
 ### get_event_class
 
@@ -169,27 +153,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -209,6 +187,100 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_errors"></a>
+### get_event_errors
+
+```
+final public get_event_errors() : array[]
+```
+
+##### Summary
+
+Gets additional information about the reason for the error.
+
+##### Description
+
+The format will be an array of arrays:
+[
+    [
+        &#039;description&#039; =&gt; &#039;A description of an error&#039;,
+        &#039;extra&#039; =&gt; [
+            &#039;extra_info_example_1&#039; =&gt; &#039;some additional information about this error&#039;,
+    ],
+    [
+        &#039;description&#039; =&gt; &#039;A description of another error&#039;,
+        &#039;extra&#039; =&gt; [
+            &#039;extra_info_example_2&#039; =&gt; &#039;some additional information about this error&#039;,
+            &#039;extra_info_example_3&#039; =&gt; &#039;even more additional information about this error&#039;,
+        ],
+    ],
+]
+
+##### Returns:
+
+```
+array[]
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Restore-Success.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Restore-Success.md
@@ -19,8 +19,11 @@ This event is sent when a restore operation succeeds.
 * public [get_domain()](#method_get_domain)
 * public [get_domain_status()](#method_get_domain_status)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_expiration_date()](#method_get_expiration_date)
 * public [get_id()](#method_get_id)
@@ -175,27 +178,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -215,6 +212,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Contacts-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Contacts-Fail.md
@@ -13,10 +13,13 @@ Event representing a `Domain\Set\Contacts` command failure
 * public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_error_detail()](#method_get_error_detail)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_errors()](#method_get_event_errors)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -126,25 +129,6 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_error_detail"></a>
-### get_error_detail
-
-```
-final public get_error_detail() : string
-```
-
-##### Summary
-
-Gets additional information about the reason for the error.
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_event_class"></a>
 ### get_event_class
 
@@ -164,27 +148,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -204,6 +182,100 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_errors"></a>
+### get_event_errors
+
+```
+final public get_event_errors() : array[]
+```
+
+##### Summary
+
+Gets additional information about the reason for the error.
+
+##### Description
+
+The format will be an array of arrays:
+[
+    [
+        &#039;description&#039; =&gt; &#039;A description of an error&#039;,
+        &#039;extra&#039; =&gt; [
+            &#039;extra_info_example_1&#039; =&gt; &#039;some additional information about this error&#039;,
+    ],
+    [
+        &#039;description&#039; =&gt; &#039;A description of another error&#039;,
+        &#039;extra&#039; =&gt; [
+            &#039;extra_info_example_2&#039; =&gt; &#039;some additional information about this error&#039;,
+            &#039;extra_info_example_3&#039; =&gt; &#039;even more additional information about this error&#039;,
+        ],
+    ],
+]
+
+##### Returns:
+
+```
+array[]
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Contacts-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Contacts-Fail.md
@@ -13,7 +13,7 @@ Event representing a `Domain\Set\Contacts` command failure
 * public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_error_reason()](#method_get_error_reason)
+* public [get_error_detail()](#method_get_error_detail)
 * public [get_event_class()](#method_get_event_class)
 * public [get_event_data()](#method_get_event_data)
 * public [get_event_date()](#method_get_event_date)
@@ -126,11 +126,11 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_error_reason"></a>
-### get_error_reason
+<a id="method_get_error_detail"></a>
+### get_error_detail
 
 ```
-final public get_error_reason() : string
+final public get_error_detail() : string
 ```
 
 ##### Summary

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Contacts-Success.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Contacts-Success.md
@@ -15,8 +15,11 @@ Event representing a `Domain\Set\Contacts` command success
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -169,27 +172,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -209,6 +206,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Nameservers-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Nameservers-Fail.md
@@ -17,7 +17,7 @@ This event is generated when a name server update fails at the server.
 * public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_error_reason()](#method_get_error_reason)
+* public [get_error_detail()](#method_get_error_detail)
 * public [get_event_class()](#method_get_event_class)
 * public [get_event_data()](#method_get_event_data)
 * public [get_event_date()](#method_get_event_date)
@@ -130,11 +130,11 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_error_reason"></a>
-### get_error_reason
+<a id="method_get_error_detail"></a>
+### get_error_detail
 
 ```
-final public get_error_reason() : string
+final public get_error_detail() : string
 ```
 
 ##### Summary

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Nameservers-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Nameservers-Fail.md
@@ -17,10 +17,13 @@ This event is generated when a name server update fails at the server.
 * public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_error_detail()](#method_get_error_detail)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_errors()](#method_get_event_errors)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -130,25 +133,6 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_error_detail"></a>
-### get_error_detail
-
-```
-final public get_error_detail() : string
-```
-
-##### Summary
-
-Gets additional information about the reason for the error.
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_event_class"></a>
 ### get_event_class
 
@@ -168,27 +152,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -208,6 +186,100 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_errors"></a>
+### get_event_errors
+
+```
+final public get_event_errors() : array[]
+```
+
+##### Summary
+
+Gets additional information about the reason for the error.
+
+##### Description
+
+The format will be an array of arrays:
+[
+    [
+        &#039;description&#039; =&gt; &#039;A description of an error&#039;,
+        &#039;extra&#039; =&gt; [
+            &#039;extra_info_example_1&#039; =&gt; &#039;some additional information about this error&#039;,
+    ],
+    [
+        &#039;description&#039; =&gt; &#039;A description of another error&#039;,
+        &#039;extra&#039; =&gt; [
+            &#039;extra_info_example_2&#039; =&gt; &#039;some additional information about this error&#039;,
+            &#039;extra_info_example_3&#039; =&gt; &#039;even more additional information about this error&#039;,
+        ],
+    ],
+]
+
+##### Returns:
+
+```
+array[]
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Nameservers-Success.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Nameservers-Success.md
@@ -19,8 +19,11 @@ Set name servers success event
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_nameservers()](#method_get_nameservers)
@@ -149,27 +152,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -189,6 +186,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Privacy-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Privacy-Fail.md
@@ -17,10 +17,13 @@ This event is generated when a privacy setting update fails at the server.
 * public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_error_detail()](#method_get_error_detail)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_errors()](#method_get_event_errors)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -130,25 +133,6 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_error_detail"></a>
-### get_error_detail
-
-```
-final public get_error_detail() : string
-```
-
-##### Summary
-
-Gets additional information about the reason for the error.
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_event_class"></a>
 ### get_event_class
 
@@ -168,27 +152,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -208,6 +186,100 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_errors"></a>
+### get_event_errors
+
+```
+final public get_event_errors() : array[]
+```
+
+##### Summary
+
+Gets additional information about the reason for the error.
+
+##### Description
+
+The format will be an array of arrays:
+[
+    [
+        &#039;description&#039; =&gt; &#039;A description of an error&#039;,
+        &#039;extra&#039; =&gt; [
+            &#039;extra_info_example_1&#039; =&gt; &#039;some additional information about this error&#039;,
+    ],
+    [
+        &#039;description&#039; =&gt; &#039;A description of another error&#039;,
+        &#039;extra&#039; =&gt; [
+            &#039;extra_info_example_2&#039; =&gt; &#039;some additional information about this error&#039;,
+            &#039;extra_info_example_3&#039; =&gt; &#039;even more additional information about this error&#039;,
+        ],
+    ],
+]
+
+##### Returns:
+
+```
+array[]
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Privacy-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Privacy-Fail.md
@@ -17,7 +17,7 @@ This event is generated when a privacy setting update fails at the server.
 * public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_error_reason()](#method_get_error_reason)
+* public [get_error_detail()](#method_get_error_detail)
 * public [get_event_class()](#method_get_event_class)
 * public [get_event_data()](#method_get_event_data)
 * public [get_event_date()](#method_get_event_date)
@@ -130,11 +130,11 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_error_reason"></a>
-### get_error_reason
+<a id="method_get_error_detail"></a>
+### get_error_detail
 
 ```
-final public get_error_reason() : string
+final public get_error_detail() : string
 ```
 
 ##### Summary

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Privacy-Success.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Privacy-Success.md
@@ -19,8 +19,11 @@ Success event for a `Domain\Set\Privacy` command
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -149,27 +152,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -189,6 +186,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Transferlock-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Transferlock-Fail.md
@@ -13,7 +13,7 @@ Fail event for `Domain\Set\TransferLock` command
 * public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_error_reason()](#method_get_error_reason)
+* public [get_error_detail()](#method_get_error_detail)
 * public [get_event_class()](#method_get_event_class)
 * public [get_event_data()](#method_get_event_data)
 * public [get_event_date()](#method_get_event_date)
@@ -126,11 +126,11 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_error_reason"></a>
-### get_error_reason
+<a id="method_get_error_detail"></a>
+### get_error_detail
 
 ```
-final public get_error_reason() : string
+final public get_error_detail() : string
 ```
 
 ##### Summary

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Transferlock-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Transferlock-Fail.md
@@ -13,10 +13,13 @@ Fail event for `Domain\Set\TransferLock` command
 * public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_error_detail()](#method_get_error_detail)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_errors()](#method_get_event_errors)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -126,25 +129,6 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_error_detail"></a>
-### get_error_detail
-
-```
-final public get_error_detail() : string
-```
-
-##### Summary
-
-Gets additional information about the reason for the error.
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_event_class"></a>
 ### get_event_class
 
@@ -164,27 +148,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -204,6 +182,100 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_errors"></a>
+### get_event_errors
+
+```
+final public get_event_errors() : array[]
+```
+
+##### Summary
+
+Gets additional information about the reason for the error.
+
+##### Description
+
+The format will be an array of arrays:
+[
+    [
+        &#039;description&#039; =&gt; &#039;A description of an error&#039;,
+        &#039;extra&#039; =&gt; [
+            &#039;extra_info_example_1&#039; =&gt; &#039;some additional information about this error&#039;,
+    ],
+    [
+        &#039;description&#039; =&gt; &#039;A description of another error&#039;,
+        &#039;extra&#039; =&gt; [
+            &#039;extra_info_example_2&#039; =&gt; &#039;some additional information about this error&#039;,
+            &#039;extra_info_example_3&#039; =&gt; &#039;even more additional information about this error&#039;,
+        ],
+    ],
+]
+
+##### Returns:
+
+```
+array[]
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Transferlock-Success.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Transferlock-Success.md
@@ -14,8 +14,11 @@ Success event for `Domain\Set\TransferLock` command
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -144,27 +147,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -184,6 +181,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-In-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-In-Fail.md
@@ -22,8 +22,11 @@ Inbound domain transfer failure event
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_execute_date()](#method_get_execute_date)
 * public [get_id()](#method_get_id)
@@ -192,27 +195,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -232,6 +229,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-In-Pending.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-In-Pending.md
@@ -20,8 +20,11 @@ This event is generated when a domain transfer from another registrar to the res
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_execute_date()](#method_get_execute_date)
 * public [get_id()](#method_get_id)
@@ -190,27 +193,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -230,6 +227,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-In-Success.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-In-Success.md
@@ -20,8 +20,11 @@ This event is generated when a domain transfer from another registrar to the res
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_execute_date()](#method_get_execute_date)
 * public [get_id()](#method_get_id)
@@ -190,27 +193,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -230,6 +227,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-Out-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-Out-Fail.md
@@ -21,8 +21,11 @@ Outbound domain transfer failure event
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_execute_date()](#method_get_execute_date)
 * public [get_id()](#method_get_id)
@@ -191,27 +194,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -231,6 +228,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-Out-Pending.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-Out-Pending.md
@@ -20,8 +20,11 @@ This event is generated when a domain transfer to another registrar is started.
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_execute_date()](#method_get_execute_date)
 * public [get_id()](#method_get_id)
@@ -190,27 +193,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -230,6 +227,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-Out-Success.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-Out-Success.md
@@ -20,8 +20,11 @@ This event is generated when a domain transfer to another registrar is successfu
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_data()](#method_get_event_data)
+* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
+* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
+* public [get_event_status()](#method_get_event_status)
+* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_execute_date()](#method_get_execute_date)
 * public [get_id()](#method_get_id)
@@ -190,27 +193,21 @@ string
 
 ---
 
-<a id="method_get_event_data"></a>
-### get_event_data
+<a id="method_get_event_client_txn_id"></a>
+### get_event_client_txn_id
 
 ```
-public get_event_data() : array
+public get_event_client_txn_id() : string
 ```
 
 ##### Summary
 
-Gets all the event data as an array
-
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \JsonException |  |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-array
+string
 ```
 
 ---
@@ -230,6 +227,63 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_server_txn_id"></a>
+### get_event_server_txn_id
+
+```
+public get_event_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_status"></a>
+### get_event_status
+
+```
+public get_event_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_event_status_description"></a>
+### get_event_status_description
+
+```
+public get_event_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Error-Trait.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Error-Trait.md
@@ -9,7 +9,7 @@ Trait that specifies methods common to all error event classes.
 
 ### Methods
 
-* public [get_error_detail()](#method_get_error_detail)
+* public [get_event_errors()](#method_get_event_errors)
 
 ---
 
@@ -21,19 +21,37 @@ Trait that specifies methods common to all error event classes.
 
 ## Methods
 
-<a id="method_get_error_detail"></a>
-### get_error_detail
+<a id="method_get_event_errors"></a>
+### get_event_errors
 
 ```
-final public get_error_detail() : string
+final public get_event_errors() : array[]
 ```
 
 ##### Summary
 
 Gets additional information about the reason for the error.
 
+##### Description
+
+The format will be an array of arrays:
+[
+    [
+        &#039;description&#039; =&gt; &#039;A description of an error&#039;,
+        &#039;extra&#039; =&gt; [
+            &#039;extra_info_example_1&#039; =&gt; &#039;some additional information about this error&#039;,
+    ],
+    [
+        &#039;description&#039; =&gt; &#039;A description of another error&#039;,
+        &#039;extra&#039; =&gt; [
+            &#039;extra_info_example_2&#039; =&gt; &#039;some additional information about this error&#039;,
+            &#039;extra_info_example_3&#039; =&gt; &#039;even more additional information about this error&#039;,
+        ],
+    ],
+]
+
 ##### Returns:
 
 ```
-string
+array[]
 ```

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Error-Trait.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Error-Trait.md
@@ -9,7 +9,7 @@ Trait that specifies methods common to all error event classes.
 
 ### Methods
 
-* public [get_error_reason()](#method_get_error_reason)
+* public [get_error_detail()](#method_get_error_detail)
 
 ---
 
@@ -21,11 +21,11 @@ Trait that specifies methods common to all error event classes.
 
 ## Methods
 
-<a id="method_get_error_reason"></a>
-### get_error_reason
+<a id="method_get_error_detail"></a>
+### get_error_detail
 
 ```
-final public get_error_reason() : string
+final public get_error_detail() : string
 ```
 
 ##### Summary

--- a/lib/event/data-trait.php
+++ b/lib/event/data-trait.php
@@ -126,12 +126,38 @@ trait Data_Trait {
 	}
 
 	/**
-	 * Gets all the event data as an array
+	 * Gets the status code for this event
 	 *
-	 * @return array
-	 * @throws \JsonException
+	 * @return int
 	 */
-	public function get_event_data(): array {
-		return json_decode( $this->get_data_by_key( 'event_data' ), true, 512, JSON_THROW_ON_ERROR );
+	public function get_event_status(): ?int {
+		return $this->get_data_by_key( 'event_data.status' );
+	}
+
+	/**
+	 * Gets a description of the status code meaning
+	 *
+	 * @return string
+	 */
+	public function get_event_status_description(): ?string {
+		return $this->get_data_by_key( 'event_data.status_description' );
+	}
+
+	/**
+	 * Gets the client_txn_id from the command related to this event, if any
+	 *
+	 * @return string
+	 */
+	public function get_event_client_txn_id(): ?string {
+		return $this->get_data_by_key( 'event_data.client_txn_id' );
+	}
+
+	/**
+	 * Gets the server_txn_id from the command related to this event, if any
+	 *
+	 * @return string
+	 */
+	public function get_event_server_txn_id(): ?string {
+		return $this->get_data_by_key( 'event_data.server_txn_id' );
 	}
 }

--- a/lib/event/error-trait.php
+++ b/lib/event/error-trait.php
@@ -28,7 +28,7 @@ trait Error_Trait {
 	 *
 	 * @return string
 	 */
-	final public function get_error_reason(): string {
-		return $this->get_data_by_key( 'event_data.error.data.reason' );
+	final public function get_error_detail(): string {
+		return $this->get_data_by_key( 'event_data.error.data.error_detail' );
 	}
 }

--- a/lib/event/error-trait.php
+++ b/lib/event/error-trait.php
@@ -26,9 +26,25 @@ trait Error_Trait {
 	/**
 	 * Gets additional information about the reason for the error.
 	 *
-	 * @return string
+	 * The format will be an array of arrays:
+	 *    [
+	 *        [
+	 *            'description' => 'A description of an error',
+	 *            'extra' => [
+	 *                'extra_info_example_1' => 'some additional information about this error',
+	 *        ],
+	 *        [
+	 *            'description' => 'A description of another error',
+	 *            'extra' => [
+	 *                'extra_info_example_2' => 'some additional information about this error',
+	 *                'extra_info_example_3' => 'even more additional information about this error',
+	 *            ],
+	 *        ],
+	 *    ]
+	 *
+	 * @return array[]
 	 */
-	final public function get_error_detail(): string {
-		return $this->get_data_by_key( 'event_data.error.data.error_detail' );
+	final public function get_event_errors(): array {
+		return $this->get_data_by_key( 'event_data.errors' );
 	}
 }

--- a/lib/exception/domain-services-exception.php
+++ b/lib/exception/domain-services-exception.php
@@ -37,20 +37,6 @@ class Domain_Services_Exception extends \Exception {
 	}
 
 	/**
-	 * Returns the type of exception - associative array with exception class and subclass
-	 *
-	 * @internal
-	 *
-	 * @return array
-	 */
-	public function get_exception_type(): array {
-		return [
-			'class' => null,
-			'subclass' => 'Domain_Services',
-		];
-	}
-
-	/**
 	 * Returns the error data associated with the exception
 	 *
 	 * @return array

--- a/test/event/contact-verification-notify-test.php
+++ b/test/event/contact-verification-notify-test.php
@@ -57,6 +57,7 @@ class Contact_Verification_Notify_Test extends Test\Lib\Domain_Services_Client_T
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Contact\Verification\Notify::class, $event );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['verified'], $event->is_verified() );
 		$this->assertSame( $response_data['data']['event']['object_id'], (string) $event->get_contact_id() );
 	}

--- a/test/event/contact-verification-request-test.php
+++ b/test/event/contact-verification-request-test.php
@@ -58,6 +58,7 @@ class Contact_Verification_Request_Test extends Test\Lib\Domain_Services_Client_
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Contact\Verification\Request::class, $event );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['email'], $event->get_email() );
 		$this->assertSame( $response_data['data']['event']['object_id'], (string) $event->get_contact_id() );
 	}

--- a/test/event/domain-delete-fail-test.php
+++ b/test/event/domain-delete-fail-test.php
@@ -42,12 +42,23 @@ class Domain_Delete_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case 
 					'event_date' => '2022-01-23 12:34:56',
 					'acknowledged_date' => null,
 					'event_data' => [
-						// TODO: Provide accurate error data once this is finalized in the server repo
-						'error' => [
-							'class' => '',
-							'subclass' => 'Domain_Services',
-							'data' => [
-								'error_detail' => 'Entity not found',
+						'status' => Response\Code::COMMAND_FAILED,
+						'status_description' => Response\Code::get_description( Response\Code::COMMAND_FAILED ),
+						'client_txn_id' => 'test-client-transaction-id',
+						'server_txn_id' => '5ffdba44-eeec-4647-9cc4-27cdf8352efc.local-isolated-test-request',
+						'errors' => [
+							[
+								'description' => 'Missing country code.',
+								'extra' => [
+									'error_info_1' => 'some information about this error',
+								],
+							],
+							[
+								'description' => 'Missing country code.',
+								'extra' => [
+									'error_info_1' => 'some information about this error',
+									'error_info_2' => 'some additional information about this error',
+								],
 							],
 						],
 					],
@@ -64,8 +75,7 @@ class Domain_Delete_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case 
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Delete\Fail::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
-		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['error_detail'], $event->get_error_detail() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 	}
 }
 

--- a/test/event/domain-delete-fail-test.php
+++ b/test/event/domain-delete-fail-test.php
@@ -46,10 +46,9 @@ class Domain_Delete_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case 
 						'error' => [
 							'class' => '',
 							'subclass' => 'Domain_Services',
-							'data' =>
-								[
-									'reason' => 'Entity not found',
-								],
+							'data' => [
+								'error_detail' => 'Entity not found',
+							],
 						],
 					],
 				],
@@ -66,6 +65,7 @@ class Domain_Delete_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case 
 
 		$this->assertInstanceOf( Event\Domain\Delete\Fail::class, $event );
 		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
-		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['reason'], $event->get_error_reason() );
+		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['error_detail'], $event->get_error_detail() );
 	}
 }
+

--- a/test/event/domain-delete-success-test.php
+++ b/test/event/domain-delete-success-test.php
@@ -55,6 +55,6 @@ class Domain_Delete_Success_Test extends Test\Lib\Domain_Services_Client_Test_Ca
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Delete\Success::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 	}
 }

--- a/test/event/domain-notification-argp-test.php
+++ b/test/event/domain-notification-argp-test.php
@@ -57,7 +57,7 @@ class Domain_Notification_Argp_Test extends Test\Lib\Domain_Services_Client_Test
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Notification\Argp::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['argp_end_date'], Helper\Date_Time::format( $event->get_argp_end_date() ) );
 	}
 }

--- a/test/event/domain-notification-auction-test.php
+++ b/test/event/domain-notification-auction-test.php
@@ -58,7 +58,7 @@ class Domain_Notification_Auction_Test extends Test\Lib\Domain_Services_Client_T
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Notification\Auction::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['auction_status'], $event->get_auction_status() );
 		$this->assertSame( $response_data['data']['event']['event_data']['auction_status_end_date'], Helper\Date_Time::format( $event->get_auction_status_end_date() ) );
 	}

--- a/test/event/domain-notification-pending-delete-test.php
+++ b/test/event/domain-notification-pending-delete-test.php
@@ -57,7 +57,7 @@ class Domain_Notification_Pending_Delete_Test extends Test\Lib\Domain_Services_C
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Notification\Pending_Delete::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['pending_delete_end_date'], Helper\Date_Time::format( $event->get_pending_delete_end_date() ) );
 	}
 }

--- a/test/event/domain-notification-redemption-test.php
+++ b/test/event/domain-notification-redemption-test.php
@@ -57,7 +57,7 @@ class Domain_Notification_Redemption_Test extends Test\Lib\Domain_Services_Clien
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Notification\Redemption::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['redemption_end_date'], Helper\Date_Time::format( $event->get_redemption_end_date() ) );
 	}
 }

--- a/test/event/domain-notification-suspended-test.php
+++ b/test/event/domain-notification-suspended-test.php
@@ -57,7 +57,7 @@ class Domain_Notification_Suspended_Test extends Test\Lib\Domain_Services_Client
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Notification\Suspended::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['info'], $event->get_info() );
 	}
 }

--- a/test/event/domain-notification-verified-test.php
+++ b/test/event/domain-notification-verified-test.php
@@ -57,7 +57,7 @@ class Domain_Notification_Verified_Test extends Test\Lib\Domain_Services_Client_
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Notification\Verified::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['info'], $event->get_info() );
 	}
 }

--- a/test/event/domain-register-fail-test.php
+++ b/test/event/domain-register-fail-test.php
@@ -42,12 +42,23 @@ class Domain_Register_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Cas
 					'event_date' => '2022-01-23 12:34:56',
 					'acknowledged_date' => null,
 					'event_data' => [
-						// TODO: Provide accurate error data once this is finalized in the server repo
-						'error' => [
-							'class' => '',
-							'subclass' => 'Domain_Services',
-							'data' => [
-								'error_detail' => 'Domain is not available',
+						'status' => Response\Code::COMMAND_FAILED,
+						'status_description' => Response\Code::get_description( Response\Code::COMMAND_FAILED ),
+						'client_txn_id' => 'test-client-transaction-id',
+						'server_txn_id' => '5ffdba44-eeec-4647-9cc4-27cdf8352efc.local-isolated-test-request',
+						'errors' => [
+							[
+								'description' => 'Missing country code.',
+								'extra' => [
+									'error_info_1' => 'some information about this error',
+								],
+							],
+							[
+								'description' => 'Missing country code.',
+								'extra' => [
+									'error_info_1' => 'some information about this error',
+									'error_info_2' => 'some additional information about this error',
+								],
 							],
 						],
 					],
@@ -64,7 +75,6 @@ class Domain_Register_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Cas
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Register\Fail::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
-		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['error_detail'], $event->get_error_detail() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 	}
 }

--- a/test/event/domain-register-fail-test.php
+++ b/test/event/domain-register-fail-test.php
@@ -46,10 +46,9 @@ class Domain_Register_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Cas
 						'error' => [
 							'class' => '',
 							'subclass' => 'Domain_Services',
-							'data' =>
-								[
-									'reason' => 'Domain is not available',
-								],
+							'data' => [
+								'error_detail' => 'Domain is not available',
+							],
 						],
 					],
 				],
@@ -66,6 +65,6 @@ class Domain_Register_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Cas
 
 		$this->assertInstanceOf( Event\Domain\Register\Fail::class, $event );
 		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
-		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['reason'], $event->get_error_reason() );
+		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['error_detail'], $event->get_error_detail() );
 	}
 }

--- a/test/event/domain-register-success-test.php
+++ b/test/event/domain-register-success-test.php
@@ -99,7 +99,7 @@ class Domain_Register_Success_Test extends Test\Lib\Domain_Services_Client_Test_
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Register\Success::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 
 		$event_contacts = $event->get_contacts();
 		foreach ( $event_contacts as $contact_type => $event_contact ) {

--- a/test/event/domain-renew-fail-test.php
+++ b/test/event/domain-renew-fail-test.php
@@ -46,10 +46,9 @@ class Domain_Renew_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 						'error' => [
 							'class' => '',
 							'subclass' => 'Domain_Services',
-							'data' =>
-								[
-									'reason' => 'Invalid attribute value; wrong expiration',
-								],
+							'data' => [
+								'error_detail' => 'Invalid attribute value; wrong expiration',
+							],
 						],
 					],
 				],
@@ -66,6 +65,6 @@ class Domain_Renew_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 
 		$this->assertInstanceOf( Event\Domain\Renew\Fail::class, $event );
 		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
-		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['reason'], $event->get_error_reason() );
+		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['error_detail'], $event->get_error_detail() );
 	}
 }

--- a/test/event/domain-renew-fail-test.php
+++ b/test/event/domain-renew-fail-test.php
@@ -42,12 +42,23 @@ class Domain_Renew_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 					'event_date' => '2022-01-23 12:34:56',
 					'acknowledged_date' => null,
 					'event_data' => [
-						// TODO: Provide accurate error data once this is finalized in the server repo
-						'error' => [
-							'class' => '',
-							'subclass' => 'Domain_Services',
-							'data' => [
-								'error_detail' => 'Invalid attribute value; wrong expiration',
+						'status' => Response\Code::COMMAND_FAILED,
+						'status_description' => Response\Code::get_description( Response\Code::COMMAND_FAILED ),
+						'client_txn_id' => 'test-client-transaction-id',
+						'server_txn_id' => '5ffdba44-eeec-4647-9cc4-27cdf8352efc.local-isolated-test-request',
+						'errors' => [
+							[
+								'description' => 'Missing country code.',
+								'extra' => [
+									'error_info_1' => 'some information about this error',
+								],
+							],
+							[
+								'description' => 'Missing country code.',
+								'extra' => [
+									'error_info_1' => 'some information about this error',
+									'error_info_2' => 'some additional information about this error',
+								],
 							],
 						],
 					],
@@ -64,7 +75,6 @@ class Domain_Renew_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Renew\Fail::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
-		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['error_detail'], $event->get_error_detail() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 	}
 }

--- a/test/event/domain-renew-success-test.php
+++ b/test/event/domain-renew-success-test.php
@@ -59,7 +59,7 @@ class Domain_Renew_Success_Test extends Test\Lib\Domain_Services_Client_Test_Cas
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Renew\Success::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 
 		$this->assertSame( $response_data['data']['event']['event_data']['domain_status'], $event->get_domain_status()->to_array() );
 		$this->assertSame( $response_data['data']['event']['event_data']['expiration_date'], Helper\Date_Time::format( $event->get_expiration_date() ) );

--- a/test/event/domain-restore-fail-test.php
+++ b/test/event/domain-restore-fail-test.php
@@ -46,10 +46,9 @@ class Domain_Restore_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case
 						'error' => [
 							'class' => '',
 							'subclass' => 'Domain_Services',
-							'data' =>
-								[
-									'reason' => 'Entity not found',
-								],
+							'data' => [
+								'error_detail' => 'Entity not found',
+							],
 						],
 					],
 				],
@@ -66,6 +65,6 @@ class Domain_Restore_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case
 
 		$this->assertInstanceOf( Event\Domain\Restore\Fail::class, $event );
 		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
-		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['reason'], $event->get_error_reason() );
+		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['error_detail'], $event->get_error_detail() );
 	}
 }

--- a/test/event/domain-restore-fail-test.php
+++ b/test/event/domain-restore-fail-test.php
@@ -42,12 +42,23 @@ class Domain_Restore_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case
 					'event_date' => '2022-01-23 12:34:56',
 					'acknowledged_date' => null,
 					'event_data' => [
-						// TODO: Provide accurate error data once this is finalized in the server repo
-						'error' => [
-							'class' => '',
-							'subclass' => 'Domain_Services',
-							'data' => [
-								'error_detail' => 'Entity not found',
+						'status' => Response\Code::COMMAND_FAILED,
+						'status_description' => Response\Code::get_description( Response\Code::COMMAND_FAILED ),
+						'client_txn_id' => 'test-client-transaction-id',
+						'server_txn_id' => '5ffdba44-eeec-4647-9cc4-27cdf8352efc.local-isolated-test-request',
+						'errors' => [
+							[
+								'description' => 'Missing country code.',
+								'extra' => [
+									'error_info_1' => 'some information about this error',
+								],
+							],
+							[
+								'description' => 'Missing country code.',
+								'extra' => [
+									'error_info_1' => 'some information about this error',
+									'error_info_2' => 'some additional information about this error',
+								],
 							],
 						],
 					],
@@ -64,7 +75,6 @@ class Domain_Restore_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Restore\Fail::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
-		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['error_detail'], $event->get_error_detail() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 	}
 }

--- a/test/event/domain-restore-success-test.php
+++ b/test/event/domain-restore-success-test.php
@@ -59,7 +59,7 @@ class Domain_Restore_Success_Test extends Test\Lib\Domain_Services_Client_Test_C
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Restore\Success::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 
 		$this->assertSame( $response_data['data']['event']['event_data']['domain_status'], $event->get_domain_status()->to_array() );
 		$this->assertSame( $response_data['data']['event']['event_data']['expiration_date'], Helper\Date_Time::format( $event->get_expiration_date() ) );

--- a/test/event/domain-set-contacts-fail-test.php
+++ b/test/event/domain-set-contacts-fail-test.php
@@ -46,11 +46,10 @@ class Domain_Set_Contacts_Fail_Test extends Test\Lib\Domain_Services_Client_Test
 						'error' => [
 							'class' => 'Entity',
 							'subclass' => 'Invalid_Value',
-							'data' =>
-								[
-									'invalid_option' => 'Automattic\\Domain_Services_Client\\Command\\Domain\\Contacts\\Contacts',
-									'reason' => 'Missing country code.',
-								],
+							'data' => [
+								'invalid_option' => 'Automattic\\Domain_Services_Client\\Command\\Domain\\Contacts\\Contacts',
+								'error_detail' => 'Missing country code.',
+							],
 						],
 					],
 				],
@@ -67,6 +66,6 @@ class Domain_Set_Contacts_Fail_Test extends Test\Lib\Domain_Services_Client_Test
 
 		$this->assertInstanceOf( Event\Domain\Set\Contacts\Fail::class, $event );
 		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
-		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['reason'], $event->get_error_reason() );
+		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['error_detail'], $event->get_error_detail() );
 	}
 }

--- a/test/event/domain-set-contacts-fail-test.php
+++ b/test/event/domain-set-contacts-fail-test.php
@@ -42,13 +42,23 @@ class Domain_Set_Contacts_Fail_Test extends Test\Lib\Domain_Services_Client_Test
 					'event_date' => '2022-01-23 12:34:56',
 					'acknowledged_date' => null,
 					'event_data' => [
-						// TODO: Provide accurate error data once this is finalized in the server repo
-						'error' => [
-							'class' => 'Entity',
-							'subclass' => 'Invalid_Value',
-							'data' => [
-								'invalid_option' => 'Automattic\\Domain_Services_Client\\Command\\Domain\\Contacts\\Contacts',
-								'error_detail' => 'Missing country code.',
+						'status' => Response\Code::COMMAND_FAILED,
+						'status_description' => Response\Code::get_description( Response\Code::COMMAND_FAILED ),
+						'client_txn_id' => 'test-client-transaction-id',
+						'server_txn_id' => '5ffdba44-eeec-4647-9cc4-27cdf8352efc.local-isolated-test-request',
+						'errors' => [
+							[
+								'description' => 'Missing country code.',
+								'extra' => [
+									'error_info_1' => 'some information about this error',
+								],
+							],
+							[
+								'description' => 'Missing country code.',
+								'extra' => [
+									'error_info_1' => 'some information about this error',
+									'error_info_2' => 'some additional information about this error',
+								],
 							],
 						],
 					],
@@ -62,10 +72,8 @@ class Domain_Set_Contacts_Fail_Test extends Test\Lib\Domain_Services_Client_Test
 		$this->assertIsValidResponse( $response_data, $response_object );
 
 		$event = $response_object->get_event();
-		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Set\Contacts\Fail::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
-		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['error_detail'], $event->get_error_detail() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 	}
 }

--- a/test/event/domain-set-contacts-success-test.php
+++ b/test/event/domain-set-contacts-success-test.php
@@ -83,7 +83,7 @@ class Domain_Set_Contacts_Success_Test extends Test\Lib\Domain_Services_Client_T
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Set\Contacts\Success::class, $event );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['contacts'], $event->get_contacts()->to_array() );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
 	}
 }

--- a/test/event/domain-set-nameservers-fail-test.php
+++ b/test/event/domain-set-nameservers-fail-test.php
@@ -47,7 +47,7 @@ class Domain_Set_Nameservers_Fail_Test extends Test\Lib\Domain_Services_Client_T
 							'class' => '',
 							'subclass' => 'Domain_Services',
 							'data' => [
-								'reason' => 'Entity not found',
+								'error_detail' => 'Entity not found',
 							],
 						],
 					],
@@ -65,6 +65,6 @@ class Domain_Set_Nameservers_Fail_Test extends Test\Lib\Domain_Services_Client_T
 
 		$this->assertInstanceOf( Event\Domain\Set\Nameservers\Fail::class, $event );
 		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
-		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['reason'], $event->get_error_reason() );
+		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['error_detail'], $event->get_error_detail() );
 	}
 }

--- a/test/event/domain-set-nameservers-fail-test.php
+++ b/test/event/domain-set-nameservers-fail-test.php
@@ -42,12 +42,23 @@ class Domain_Set_Nameservers_Fail_Test extends Test\Lib\Domain_Services_Client_T
 					'event_date' => '2022-01-23 12:34:56',
 					'acknowledged_date' => null,
 					'event_data' => [
-						// TODO: Provide accurate error data once this is finalized in the server repo
-						'error' => [
-							'class' => '',
-							'subclass' => 'Domain_Services',
-							'data' => [
-								'error_detail' => 'Entity not found',
+						'status' => Response\Code::COMMAND_FAILED,
+						'status_description' => Response\Code::get_description( Response\Code::COMMAND_FAILED ),
+						'client_txn_id' => 'test-client-transaction-id',
+						'server_txn_id' => '5ffdba44-eeec-4647-9cc4-27cdf8352efc.local-isolated-test-request',
+						'errors' => [
+							[
+								'description' => 'Missing country code.',
+								'extra' => [
+									'error_info_1' => 'some information about this error',
+								],
+							],
+							[
+								'description' => 'Missing country code.',
+								'extra' => [
+									'error_info_1' => 'some information about this error',
+									'error_info_2' => 'some additional information about this error',
+								],
 							],
 						],
 					],
@@ -64,7 +75,6 @@ class Domain_Set_Nameservers_Fail_Test extends Test\Lib\Domain_Services_Client_T
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Set\Nameservers\Fail::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
-		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['error_detail'], $event->get_error_detail() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 	}
 }

--- a/test/event/domain-set-nameservers-success-test.php
+++ b/test/event/domain-set-nameservers-success-test.php
@@ -60,7 +60,7 @@ class Domain_Set_Nameservers_Success_Test extends Test\Lib\Domain_Services_Clien
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Set\Nameservers\Success::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['name_servers'], $event->get_nameservers()->to_array() );
 	}
 }

--- a/test/event/domain-set-privacy-fail-test.php
+++ b/test/event/domain-set-privacy-fail-test.php
@@ -46,11 +46,10 @@ class Domain_Set_Privacy_Fail_Test extends Test\Lib\Domain_Services_Client_Test_
 						'error' => [
 							'class' => 'Entity',
 							'subclass' => 'Invalid_Value',
-							'data' =>
-								[
-									'invalid_option' => 'Automattic\\Domain_Services_Client\\Command\\Domain\\Privacy\\Set',
-									'reason' => 'Invalid privacy option.',
-								],
+							'data' => [
+								'invalid_option' => 'Automattic\\Domain_Services_Client\\Command\\Domain\\Privacy\\Set',
+								'error_detail' => 'Invalid privacy option.',
+							],
 						],
 					],
 				],
@@ -67,6 +66,6 @@ class Domain_Set_Privacy_Fail_Test extends Test\Lib\Domain_Services_Client_Test_
 
 		$this->assertInstanceOf( Event\Domain\Set\Privacy\Fail::class, $event );
 		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
-		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['reason'], $event->get_error_reason() );
+		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['error_detail'], $event->get_error_detail() );
 	}
 }

--- a/test/event/domain-set-privacy-fail-test.php
+++ b/test/event/domain-set-privacy-fail-test.php
@@ -42,13 +42,23 @@ class Domain_Set_Privacy_Fail_Test extends Test\Lib\Domain_Services_Client_Test_
 					'event_date' => '2022-01-23 12:34:56',
 					'acknowledged_date' => null,
 					'event_data' => [
-						// TODO: Provide accurate error data once this is finalized in the server repo
-						'error' => [
-							'class' => 'Entity',
-							'subclass' => 'Invalid_Value',
-							'data' => [
-								'invalid_option' => 'Automattic\\Domain_Services_Client\\Command\\Domain\\Privacy\\Set',
-								'error_detail' => 'Invalid privacy option.',
+						'status' => Response\Code::COMMAND_FAILED,
+						'status_description' => Response\Code::get_description( Response\Code::COMMAND_FAILED ),
+						'client_txn_id' => 'test-client-transaction-id',
+						'server_txn_id' => '5ffdba44-eeec-4647-9cc4-27cdf8352efc.local-isolated-test-request',
+						'errors' => [
+							[
+								'description' => 'Missing country code.',
+								'extra' => [
+									'error_info_1' => 'some information about this error',
+								],
+							],
+							[
+								'description' => 'Missing country code.',
+								'extra' => [
+									'error_info_1' => 'some information about this error',
+									'error_info_2' => 'some additional information about this error',
+								],
 							],
 						],
 					],
@@ -65,7 +75,6 @@ class Domain_Set_Privacy_Fail_Test extends Test\Lib\Domain_Services_Client_Test_
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Set\Privacy\Fail::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
-		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['error_detail'], $event->get_error_detail() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 	}
 }

--- a/test/event/domain-set-privacy-success-test.php
+++ b/test/event/domain-set-privacy-success-test.php
@@ -57,7 +57,7 @@ class Domain_Set_Privacy_Success_Test extends Test\Lib\Domain_Services_Client_Te
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Set\Privacy\Success::class, $event );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['privacy_setting'], $event->get_privacy_setting()->get_setting() );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
 	}
 }

--- a/test/event/domain-set-transferlock-fail-test.php
+++ b/test/event/domain-set-transferlock-fail-test.php
@@ -42,12 +42,23 @@ class Domain_Set_Transferlock_Fail_Test extends Test\Lib\Domain_Services_Client_
 					'event_date' => '2022-01-23 12:34:56',
 					'acknowledged_date' => null,
 					'event_data' => [
-						// TODO: Provide accurate error data once this is finalized in the server repo
-						'error' => [
-							'class' => '',
-							'subclass' => 'Domain_Services',
-							'data' => [
-								'error_detail' => 'Invalid domain state',
+						'status' => Response\Code::COMMAND_FAILED,
+						'status_description' => Response\Code::get_description( Response\Code::COMMAND_FAILED ),
+						'client_txn_id' => 'test-client-transaction-id',
+						'server_txn_id' => '5ffdba44-eeec-4647-9cc4-27cdf8352efc.local-isolated-test-request',
+						'errors' => [
+							[
+								'description' => 'Missing country code.',
+								'extra' => [
+									'error_info_1' => 'some information about this error',
+								],
+							],
+							[
+								'description' => 'Missing country code.',
+								'extra' => [
+									'error_info_1' => 'some information about this error',
+									'error_info_2' => 'some additional information about this error',
+								],
 							],
 						],
 					],
@@ -64,7 +75,6 @@ class Domain_Set_Transferlock_Fail_Test extends Test\Lib\Domain_Services_Client_
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Set\Transferlock\Fail::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
-		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['error_detail'], $event->get_error_detail() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 	}
 }

--- a/test/event/domain-set-transferlock-fail-test.php
+++ b/test/event/domain-set-transferlock-fail-test.php
@@ -47,7 +47,7 @@ class Domain_Set_Transferlock_Fail_Test extends Test\Lib\Domain_Services_Client_
 							'class' => '',
 							'subclass' => 'Domain_Services',
 							'data' => [
-								'reason' => 'Invalid domain state',
+								'error_detail' => 'Invalid domain state',
 							],
 						],
 					],
@@ -65,6 +65,6 @@ class Domain_Set_Transferlock_Fail_Test extends Test\Lib\Domain_Services_Client_
 
 		$this->assertInstanceOf( Event\Domain\Set\Transferlock\Fail::class, $event );
 		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
-		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['reason'], $event->get_error_reason() );
+		$this->assertSame( $response_data['data']['event']['event_data']['error']['data']['error_detail'], $event->get_error_detail() );
 	}
 }

--- a/test/event/domain-set-transferlock-success-test.php
+++ b/test/event/domain-set-transferlock-success-test.php
@@ -57,7 +57,7 @@ class Domain_Set_Transferlock_Success_Test extends Test\Lib\Domain_Services_Clie
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Set\Transferlock\Success::class, $event );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['transferlock'], $event->is_locked() );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
 	}
 }

--- a/test/event/domain-transfer-in-fail-test.php
+++ b/test/event/domain-transfer-in-fail-test.php
@@ -62,7 +62,7 @@ class Domain_Transfer_In_Fail_Test extends Test\Lib\Domain_Services_Client_Test_
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Transfer\In\Fail::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['current_registrar'], $event->get_current_registrar() );
 		$this->assertSame( $response_data['data']['event']['event_data']['requesting_registrar'], $event->get_requesting_registrar() );
 		$this->assertSame( $response_data['data']['event']['event_data']['auto_nack'], $event->get_auto_nack() );

--- a/test/event/domain-transfer-in-pending-test.php
+++ b/test/event/domain-transfer-in-pending-test.php
@@ -62,7 +62,7 @@ class Domain_Transfer_In_Pending_Test extends Test\Lib\Domain_Services_Client_Te
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Transfer\In\Pending::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['current_registrar'], $event->get_current_registrar() );
 		$this->assertSame( $response_data['data']['event']['event_data']['requesting_registrar'], $event->get_requesting_registrar() );
 		$this->assertSame( $response_data['data']['event']['event_data']['auto_nack'], $event->get_auto_nack() );

--- a/test/event/domain-transfer-in-success-test.php
+++ b/test/event/domain-transfer-in-success-test.php
@@ -62,7 +62,7 @@ class Domain_Transfer_In_Success_Test extends Test\Lib\Domain_Services_Client_Te
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Transfer\In\Success::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['current_registrar'], $event->get_current_registrar() );
 		$this->assertSame( $response_data['data']['event']['event_data']['requesting_registrar'], $event->get_requesting_registrar() );
 		$this->assertSame( $response_data['data']['event']['event_data']['auto_nack'], $event->get_auto_nack() );

--- a/test/event/domain-transfer-out-fail-test.php
+++ b/test/event/domain-transfer-out-fail-test.php
@@ -62,7 +62,7 @@ class Domain_Transfer_Out_Fail_Test extends Test\Lib\Domain_Services_Client_Test
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Transfer\Out\Fail::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['current_registrar'], $event->get_current_registrar() );
 		$this->assertSame( $response_data['data']['event']['event_data']['requesting_registrar'], $event->get_requesting_registrar() );
 		$this->assertSame( $response_data['data']['event']['event_data']['auto_nack'], $event->get_auto_nack() );

--- a/test/event/domain-transfer-out-pending-test.php
+++ b/test/event/domain-transfer-out-pending-test.php
@@ -62,7 +62,7 @@ class Domain_Transfer_Out_Pending_Test extends Test\Lib\Domain_Services_Client_T
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Transfer\Out\Pending::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['current_registrar'], $event->get_current_registrar() );
 		$this->assertSame( $response_data['data']['event']['event_data']['requesting_registrar'], $event->get_requesting_registrar() );
 		$this->assertSame( $response_data['data']['event']['event_data']['auto_nack'], $event->get_auto_nack() );

--- a/test/event/domain-transfer-out-success-test.php
+++ b/test/event/domain-transfer-out-success-test.php
@@ -62,7 +62,7 @@ class Domain_Transfer_Out_Success_Test extends Test\Lib\Domain_Services_Client_T
 		$this->assertNotNull( $event );
 
 		$this->assertInstanceOf( Event\Domain\Transfer\Out\Success::class, $event );
-		$this->assertSame( $response_data['data']['event']['object_id'], $event->get_domain()->get_name() );
+		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['current_registrar'], $event->get_current_registrar() );
 		$this->assertSame( $response_data['data']['event']['event_data']['requesting_registrar'], $event->get_requesting_registrar() );
 		$this->assertSame( $response_data['data']['event']['event_data']['auto_nack'], $event->get_auto_nack() );

--- a/test/lib/domain-services-client-test-case.php
+++ b/test/lib/domain-services-client-test-case.php
@@ -58,10 +58,10 @@ class Domain_Services_Client_Test_Case extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals( $expected_event_data['object_id'], $event->get_object_id() );
 		$this->assertEquals( $expected_event_data['event_date'], Helper\Date_Time::format( $event->get_event_date() ) );
 		$this->assertEquals( $expected_event_data['acknowledged_date'], null === $event->get_acknowledged_date() ? null : Helper\Date_Time::format( $event->get_acknowledged_date() ) );
-		$this->assertEquals( $expected_event_data['event_data']['status'], $event->get_event_status() );
-		$this->assertEquals( $expected_event_data['event_data']['status_description'], $event->get_event_status_description() );
-		$this->assertEquals( $expected_event_data['event_data']['client_txn_id'], $event->get_event_client_txn_id() );
-		$this->assertEquals( $expected_event_data['event_data']['server_txn_id'], $event->get_event_server_txn_id() );
+		$this->assertEquals( $expected_event_data['event_data']['status'] ?? null, $event->get_event_status() );
+		$this->assertEquals( $expected_event_data['event_data']['status_description'] ?? null, $event->get_event_status_description() );
+		$this->assertEquals( $expected_event_data['event_data']['client_txn_id'] ?? null, $event->get_event_client_txn_id() );
+		$this->assertEquals( $expected_event_data['event_data']['server_txn_id'] ?? null, $event->get_event_server_txn_id() );
 
 		if ( 'domain' === $expected_event_data['object_type'] ) {
 			$this->assertSame( $expected_event_data['object_id'], $event->get_domain()->get_name() );

--- a/test/lib/domain-services-client-test-case.php
+++ b/test/lib/domain-services-client-test-case.php
@@ -18,7 +18,7 @@
 
 namespace Automattic\Domain_Services_Client\Test\Lib;
 
-use Automattic\Domain_Services_Client\{Response};
+use Automattic\Domain_Services_Client\{Event, Helper, Response};
 
 class Domain_Services_Client_Test_Case extends \PHPUnit\Framework\TestCase {
 	protected Response\Factory $response_factory;
@@ -48,6 +48,28 @@ class Domain_Services_Client_Test_Case extends \PHPUnit\Framework\TestCase {
 
 		$this->assertIsString( $response->get_status_description() );
 		$this->assertEquals( $expected_data['status_description'], $response->get_status_description() );
+	}
+
+	public function assertIsValidEvent( array $expected_event_data, Event\Event_Interface $event ): void {
+		$this->assertEquals( $expected_event_data['id'], $event->get_id() );
+		$this->assertEquals( $expected_event_data['event_class'], $event->get_event_class() );
+		$this->assertEquals( $expected_event_data['event_subclass'], $event->get_event_subclass() );
+		$this->assertEquals( $expected_event_data['object_type'], $event->get_object_type() );
+		$this->assertEquals( $expected_event_data['object_id'], $event->get_object_id() );
+		$this->assertEquals( $expected_event_data['event_date'], Helper\Date_Time::format( $event->get_event_date() ) );
+		$this->assertEquals( $expected_event_data['acknowledged_date'], null === $event->get_acknowledged_date() ? null : Helper\Date_Time::format( $event->get_acknowledged_date() ) );
+		$this->assertEquals( $expected_event_data['event_data']['status'], $event->get_event_status() );
+		$this->assertEquals( $expected_event_data['event_data']['status_description'], $event->get_event_status_description() );
+		$this->assertEquals( $expected_event_data['event_data']['client_txn_id'], $event->get_event_client_txn_id() );
+		$this->assertEquals( $expected_event_data['event_data']['server_txn_id'], $event->get_event_server_txn_id() );
+
+		if ( 'domain' === $expected_event_data['object_type'] ) {
+			$this->assertSame( $expected_event_data['object_id'], $event->get_domain()->get_name() );
+		}
+
+		if ( is_callable( [ $event, 'get_event_errors' ] ) ) {
+			$this->assertEquals( $expected_event_data['event_data']['errors'], $event->get_event_errors() );
+		}
 	}
 
 	private function ksortMultidimensionalArray( array &$array ): void {

--- a/test/response/event-details-test.php
+++ b/test/response/event-details-test.php
@@ -37,11 +37,16 @@ class Event_Details_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 					'id' => 1234,
 					'event_class' => 'Domain\Set\Nameservers',
 					'event_subclass' => 'Success',
-					'event_data' => '[]',
 					'object_type' => 'domain',
 					'object_id' => 'example.com',
-					'event_date' => '2022-08-01 01:23:45',
+					'event_date' => '2022-01-23 12:34:56',
 					'acknowledged_date' => '2022-08-02 06:07:08',
+					'event_data' => [
+						'name_servers' => [
+							'ns1.wordpress.com',
+							'ns2.wordpress.com',
+						],
+					],
 				],
 			],
 		];
@@ -59,7 +64,6 @@ class Event_Details_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 		$this->assertEquals( $expected_response_data['event_date'], $event->get_event_date()->format( 'Y-m-d H:i:s' ) );
 		$this->assertEquals( $expected_response_data['acknowledged_date'], $event->get_acknowledged_date()->format( 'Y-m-d H:i:s' ) );
 		$this->assertEquals( $expected_response_data['event_class'], $event->get_event_class() );
-		$this->assertEquals( $expected_response_data['event_data'], json_encode( $event->get_event_data(), JSON_THROW_ON_ERROR ) );
 		$this->assertEquals( $expected_response_data['event_subclass'], $event->get_event_subclass() );
 		$this->assertEquals( $expected_response_data['id'], $event->get_id() );
 		$this->assertEquals( $expected_response_data['object_id'], $event->get_object_id() );

--- a/test/response/events-enumerate-test.php
+++ b/test/response/events-enumerate-test.php
@@ -39,7 +39,7 @@ class Event_Enumerate_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 						'id' => 1,
 						'event_class' => 'Domain\Set\Nameservers',
 						'event_subclass' => 'Success',
-						'event_data' => '[]',
+						'event_data' => [],
 						'object_type' => 'domain',
 						'object_id' => 'example.com',
 						'event_date' => '2022-01-01 00:00:00',
@@ -49,7 +49,7 @@ class Event_Enumerate_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 						'id' => 2,
 						'event_class' => 'Domain\Set\Nameservers',
 						'event_subclass' => 'Success',
-						'event_data' => '[]',
+						'event_data' => [],
 						'object_type' => 'domain',
 						'object_id' => 'example.com',
 						'event_date' => '2022-02-01 00:00:00',
@@ -59,7 +59,7 @@ class Event_Enumerate_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 						'id' => 3,
 						'event_class' => 'Domain\Set\Nameservers',
 						'event_subclass' => 'Success',
-						'event_data' => '[]',
+						'event_data' => [],
 						'object_type' => 'domain',
 						'object_id' => 'example.com',
 						'event_date' => '2022-03-01 00:00:00',
@@ -89,7 +89,6 @@ class Event_Enumerate_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 		$total_count = $response_object->get_total_count();
 
 		foreach ( $events as $index => $event ) {
-			$this->assertEquals( $response_data['data']['events'][ $index ]['event_data'], json_encode( $event->get_event_data(), JSON_THROW_ON_ERROR ) );
 			$this->assertEquals( $response_data['data']['events'][ $index ]['object_type'], $event->get_object_type() );
 			$this->assertEquals( $response_data['data']['events'][ $index ]['object_id'], $event->get_object_id() );
 			$this->assertEquals( $response_data['data']['events'][ $index ]['event_subclass'], $event->get_event_subclass() );


### PR DESCRIPTION
This PR standardizes the event error data and adds methods to access the additional event data.

Also updates the docs and tests with these changes.

Testing:
Inspect the code, make sure it matches the data that will be returned by the server.
Run the unit tests: `composer update; ./vendor/bin/phpunit -c ./test/phpunit.xml`