### PR TITLE
Allow non-standard EPP status codes

### DIFF
--- a/lib/entity/epp-status-code.php
+++ b/lib/entity/epp-status-code.php
@@ -56,7 +56,7 @@ class Epp_Status_Code {
 	private const READ_ONLY = 'read_only';
 	private const READ_WRITE = 'read_write';
 
-	public const VALID_EPP_STATUSES = [
+	public const ICANN_EPP_STATUSES = [
 		self::CLIENT_DELETE_PROHIBITED => self::READ_WRITE,
 		self::CLIENT_HOLD => self::READ_WRITE,
 		self::CLIENT_RENEW_PROHIBITED => self::READ_WRITE,
@@ -90,15 +90,21 @@ class Epp_Status_Code {
 	private string $status;
 
 	/**
+	 * The status is an ICANN standard status
+	 *
+	 * @var bool
+	 */
+	private bool $is_icann_status = true;
+
+	/**
 	 * Constructs an `Epp_Status_Code` entity
 	 *
 	 * @param string $status
 	 *
-	 * @throws \Automattic\Domain_Services_Client\Exception\Entity\Invalid_Value_Exception
 	 */
 	public function __construct( string $status ) {
-		if ( ! isset( self::VALID_EPP_STATUSES[ $status ] ) ) {
-			throw new Exception\Entity\Invalid_Value_Exception( strtolower( __CLASS__ ), $status );
+		if ( ! isset( self::ICANN_EPP_STATUSES[ $status ] ) ) {
+			$this->is_icann_status = false;
 		}
 
 		$this->status = $status;
@@ -107,20 +113,29 @@ class Epp_Status_Code {
 	/**
 	 * Returns the string representation of the EPP status code object.
 	 *
+	 * @return string
 	 * @internal
 	 *
-	 * @return string
 	 */
 	public function __toString(): string {
 		return $this->status;
 	}
 
 	/**
-	 * Checks whether the EPP status is updateable
+	 * Checks wither this a standard ICANN EPP status code
+	 *
+	 * @return bool
+	 */
+	public function is_icann_status(): bool {
+		return $this->is_icann_status;
+	}
+
+	/**
+	 * Checks whether the EPP status is able to be set by the registrar
 	 *
 	 * @return bool
 	 */
 	public function is_updateable(): bool {
-		return self::READ_WRITE === self::VALID_EPP_STATUSES[ $this->status ];
+		return self::READ_WRITE === self::ICANN_EPP_STATUSES[ $this->status ];
 	}
 }

--- a/test/entity/epp-status-code-test.php
+++ b/test/entity/epp-status-code-test.php
@@ -18,13 +18,13 @@
 
 namespace Automattic\Domain_Services_Client\Test\Entity;
 
-use Automattic\Domain_Services_Client\{Entity, Exception, Response, Test};
+use Automattic\Domain_Services_Client\{Entity, Test};
 
 class EPP_Status_Code_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	/**
 	 * <status>, <is_updateable>
 	 */
-	public const VALID_EPP_STATUSES = [
+	public const ICANN_EPP_STATUSES = [
 		'clientDeleteProhibited' => true,
 		'clientHold' => true,
 		'clientRenewProhibited' => true,
@@ -51,17 +51,16 @@ class EPP_Status_Code_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	];
 
 	public function test_entity_instance_success_disclose_all(): void {
-		foreach ( self::VALID_EPP_STATUSES as $status => $is_updateable ) {
+		foreach ( self::ICANN_EPP_STATUSES as $status => $is_updateable ) {
 			$entity = new Entity\Epp_Status_Code( $status );
 			$this->assertSame( $status, (string) $entity );
 			$this->assertSame( $is_updateable, $entity->is_updateable() );
+			$this->assertTrue( $entity->is_icann_status() );
 		}
 	}
 
 	public function test_entity_instance_fail(): void {
-		$this->expectException( Exception\Entity\Invalid_Value_Exception::class );
-		$this->expectExceptionCode( Response\Code::INVALID_ENTITY_VALUE );
-		$this->expectExceptionMessage( Response\Code::get_description( Response\Code::INVALID_ENTITY_VALUE ) );
-		new Entity\Epp_Status_Code( 'INVALID' );
+		$entity = new Entity\Epp_Status_Code( 'Non-standard EPP code' );
+		$this->assertFalse( $entity->is_icann_status() );
 	}
 }

--- a/test/entity/epp-status-code-test.php
+++ b/test/entity/epp-status-code-test.php
@@ -59,7 +59,7 @@ class EPP_Status_Code_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 		}
 	}
 
-	public function test_entity_instance_fail(): void {
+	public function test_non_icann_epp_status(): void {
 		$entity = new Entity\Epp_Status_Code( 'Non-standard EPP code' );
 		$this->assertFalse( $entity->is_icann_status() );
 	}

--- a/test/entity/epp-status-codes-test.php
+++ b/test/entity/epp-status-codes-test.php
@@ -23,7 +23,7 @@ use Automattic\Domain_Services_Client\{Entity, Test};
 class Epp_Status_Codes_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_entity_instance_success(): void {
 		$status_codes_entities = [];
-		$status_codes_array = array_keys( Entity\Epp_Status_Code::VALID_EPP_STATUSES );
+		$status_codes_array = array_keys( Entity\Epp_Status_Code::ICANN_EPP_STATUSES );
 		foreach ( $status_codes_array as $code ) {
 			$status_codes_entities[] = new Entity\Epp_Status_Code( $code );
 		}
@@ -38,7 +38,7 @@ class Epp_Status_Codes_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	}
 
 	public function test_entity_instance_using_add_success(): void {
-		$status_codes_array = array_keys( Entity\Epp_Status_Code::VALID_EPP_STATUSES );
+		$status_codes_array = array_keys( Entity\Epp_Status_Code::ICANN_EPP_STATUSES );
 		$entity = new Entity\Epp_Status_Codes();
 
 		foreach ( $status_codes_array as $code ) {


### PR DESCRIPTION
We need to allow non-standard EPP statuses since some registries will have their own statuses.

This PR just allows for these non-standard statuses and sets an `is_icann_status` flag to determine whether or not the status is a standard ICANN status.

Test using the unit tests: `composer update; ./vendor/bin/phpunit -c ./test/phpunit.xml`