### PR TITLE
Fix attribute naming inconsistency between server and client DNS commands

### DIFF
--- a/lib/command/command-interface.php
+++ b/lib/command/command-interface.php
@@ -45,7 +45,7 @@ interface Command_Interface {
 	public const KEY_QUANTITY = 'quantity';
 	public const KEY_QUERY = 'query';
 	public const KEY_RECORD_SETS = 'record_sets';
-	public const KEY_RECORDS = 'records';
+	public const KEY_RECORDS = 'dns_records';
 	public const KEY_TRANSFERLOCK = 'transferlock';
 
 	/**

--- a/lib/command/domain/register.php
+++ b/lib/command/domain/register.php
@@ -250,9 +250,15 @@ class Register implements Command\Command_Interface, Command\Command_Serialize_I
 	 * @return array
 	 */
 	public function to_array(): array {
-		return [
+		$array = [
 			Command\Command_Interface::KEY_DOMAIN => $this->get_domain()->get_name(),
 			Command\Command_Interface::KEY_CONTACTS => $this->get_contacts()->to_array(),
 		];
+
+		if ( $this->get_dns_records() ) {
+			$array[ Command\Command_Interface::KEY_RECORDS ] = $this->get_dns_records()->to_array();
+		}
+
+		return $array;
 	}
 }


### PR DESCRIPTION
- Fix an inconsistency in the DNS records attribute naming between server and client
- Add the `dns_records` attribute to the `Domain\Register` command

### Testing

- Ensure unit tests are passing:
```
composer update; ./vendor/bin/phpunit -c ./test/phpunit.xml
```