### PR TITLE
New async command related trait and interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,10 @@
     "classmap": [
       "test/"
     ]
+  },
+  "config": {
+    "allow-plugins": {
+      "php-http/discovery": false
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,5 @@
     "classmap": [
       "test/"
     ]
-  },
-  "config": {
-    "allow-plugins": {
-      "php-http/discovery": false
-    }
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,4 +6,4 @@
 
 
 --------
-> This document was automatically generated from source code comments on 2023-02-15
+> This document was automatically generated from source code comments on 2023-02-17

--- a/docs/classes/Automattic-Domain-Services-Client-Command-Command-Interface.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Command-Command-Interface.md
@@ -176,7 +176,7 @@ KEY_RECORD_SETS = 'record_sets'
 <a id="constant_KEY_RECORDS"></a>
 ###### KEY_RECORDS
 ```
-KEY_RECORDS = 'records'
+KEY_RECORDS = 'dns_records'
 ```
 
 

--- a/docs/classes/Automattic-Domain-Services-Client-Command-Event-Enumerate.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Command-Event-Enumerate.md
@@ -10,7 +10,8 @@ This command is used to request a list of the unacknowledged events. On success,
 array of events in ascending order by age (oldest to newest). The maximum number of events returned in the response,
 can be set using the `$limit` property for this command. The limit defaults to 50 if none is set.
 - This command executes synchronously on the server.
-- The corresponding response object will include the list of events.
+- The corresponding response object will include the list of events and the total number of unacknowledged events
+  for the reseller.
 
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Entity-Epp-Status-Code.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Entity-Epp-Status-Code.md
@@ -31,13 +31,14 @@ Represents an EPP status code
 * public [SERVER_TRANSFER_PROHIBITED](#constant_SERVER_TRANSFER_PROHIBITED)
 * public [SERVER_UPDATE_PROHIBITED](#constant_SERVER_UPDATE_PROHIBITED)
 * public [TRANSFER_PERIOD](#constant_TRANSFER_PERIOD)
-* public [VALID_EPP_STATUSES](#constant_VALID_EPP_STATUSES)
+* public [ICANN_EPP_STATUSES](#constant_ICANN_EPP_STATUSES)
 
 ---
 
 ### Methods
 
 * public [__construct()](#method___construct)
+* public [is_icann_status()](#method_is_icann_status)
 * public [is_updateable()](#method_is_updateable)
 
 ---
@@ -210,10 +211,10 @@ TRANSFER_PERIOD = 'transferPeriod'
 ```
 
 
-<a id="constant_VALID_EPP_STATUSES"></a>
-###### VALID_EPP_STATUSES
+<a id="constant_ICANN_EPP_STATUSES"></a>
+###### ICANN_EPP_STATUSES
 ```
-VALID_EPP_STATUSES = [self::CLIENT_DELETE_PROHIBITED => self::READ_WRITE, self::CLIENT_HOLD => self::READ_WRITE, self::CLIENT_RENEW_PROHIBITED => self::READ_WRITE, self::CLIENT_TRANSFER_PROHIBITED => self::READ_WRITE, self::CLIENT_UPDATE_PROHIBITED => self::READ_WRITE, self::ADD_PERIOD => self::READ_ONLY, self::AUTO_RENEW_PERIOD => self::READ_ONLY, self::INACTIVE => self::READ_ONLY, self::OK => self::READ_ONLY, self::PENDING_CREATE => self::READ_ONLY, self::PENDING_DELETE => self::READ_ONLY, self::PENDING_RENEW => self::READ_ONLY, self::PENDING_RESTORE => self::READ_ONLY, self::PENDING_TRANSFER => self::READ_ONLY, self::PENDING_UPDATE => self::READ_ONLY, self::REDEMPTION_PERIOD => self::READ_ONLY, self::RENEW_PERIOD => self::READ_ONLY, self::SERVER_DELETE_PROHIBITED => self::READ_ONLY, self::SERVER_HOLD => self::READ_ONLY, self::SERVER_RENEW_PROHIBITED => self::READ_ONLY, self::SERVER_TRANSFER_PROHIBITED => self::READ_ONLY, self::SERVER_UPDATE_PROHIBITED => self::READ_ONLY, self::TRANSFER_PERIOD => self::READ_ONLY]
+ICANN_EPP_STATUSES = [self::CLIENT_DELETE_PROHIBITED => self::READ_WRITE, self::CLIENT_HOLD => self::READ_WRITE, self::CLIENT_RENEW_PROHIBITED => self::READ_WRITE, self::CLIENT_TRANSFER_PROHIBITED => self::READ_WRITE, self::CLIENT_UPDATE_PROHIBITED => self::READ_WRITE, self::ADD_PERIOD => self::READ_ONLY, self::AUTO_RENEW_PERIOD => self::READ_ONLY, self::INACTIVE => self::READ_ONLY, self::OK => self::READ_ONLY, self::PENDING_CREATE => self::READ_ONLY, self::PENDING_DELETE => self::READ_ONLY, self::PENDING_RENEW => self::READ_ONLY, self::PENDING_RESTORE => self::READ_ONLY, self::PENDING_TRANSFER => self::READ_ONLY, self::PENDING_UPDATE => self::READ_ONLY, self::REDEMPTION_PERIOD => self::READ_ONLY, self::RENEW_PERIOD => self::READ_ONLY, self::SERVER_DELETE_PROHIBITED => self::READ_ONLY, self::SERVER_HOLD => self::READ_ONLY, self::SERVER_RENEW_PROHIBITED => self::READ_ONLY, self::SERVER_TRANSFER_PROHIBITED => self::READ_ONLY, self::SERVER_UPDATE_PROHIBITED => self::READ_ONLY, self::TRANSFER_PERIOD => self::READ_ONLY]
 ```
 
 
@@ -239,16 +240,29 @@ Constructs an `Epp_Status_Code` entity
 |------|------|---------|
 | **$status** | string |  |
 
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \Automattic\Domain_Services_Client\Exception\Entity\Invalid_Value_Exception |  |
-
 ##### Returns:
 
 ```
 mixed
+```
+
+---
+
+<a id="method_is_icann_status"></a>
+### is_icann_status
+
+```
+public is_icann_status() : bool
+```
+
+##### Summary
+
+Checks wither this a standard ICANN EPP status code
+
+##### Returns:
+
+```
+bool
 ```
 
 ---
@@ -262,7 +276,7 @@ public is_updateable() : bool
 
 ##### Summary
 
-Checks whether the EPP status is updateable
+Checks whether the EPP status is able to be set by the registrar
 
 ##### Returns:
 

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md
@@ -1,0 +1,98 @@
+# Interface: Async_Command_Related_Interface
+## Summary:
+
+Implemented by all events resulting from running an asynchronous command
+
+
+---
+
+### Methods
+
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
+
+---
+
+### Details
+
+* File: [lib/event/async-command-related-interface.php](../../lib/event/async-command-related-interface.php)
+
+---
+
+## Methods
+
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
+
+```
+public get_command_client_txn_id() : string
+```
+
+##### Summary
+
+Gets the client_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
+
+```
+public get_command_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_command_status"></a>
+### get_command_status
+
+```
+public get_command_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
+```

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md
@@ -1,0 +1,99 @@
+# Class: [\Automattic](../namespaces/automattic.md)[\Domain_Services_Client](../namespaces/automattic-domain-services-client.md)[\Event](../namespaces/automattic-domain-services-client-event.md)\Async_Command_Related_Trait
+
+## Summary:
+
+Used by all events resulting from running an asynchronous command
+
+
+---
+
+### Methods
+
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
+
+---
+
+### Details
+
+* File: [lib/event/async-command-related-trait.php](../../lib/event/async-command-related-trait.php)
+
+---
+
+## Methods
+
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
+
+```
+public get_command_client_txn_id() : string
+```
+
+##### Summary
+
+Gets the client_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
+
+```
+public get_command_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_command_status"></a>
+### get_command_status
+
+```
+public get_command_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
+```

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Contact-Verification-Notify.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Contact-Verification-Notify.md
@@ -18,11 +18,7 @@ This event indicates a change in the contact's status. It's usually generated wh
 * public [get_contact_id()](#method_get_contact_id)
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -34,6 +30,8 @@ This event indicates a change in the contact's status. It's usually generated wh
 ### Details
 
 * File: [lib/event/contact/verification/notify.php](../../lib/event/contact/verification/notify.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
 * Uses Traits:
   * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Contact_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Contact-Trait.md)
@@ -115,7 +113,7 @@ Returns the contact object.
 ### get_data_by_key
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+final public get_data_by_key(string  key) : mixed
 ```
 
 ##### Summary
@@ -131,7 +129,7 @@ Gets the value of the event data specified by the given key.
 ##### Returns:
 
 ```
-array|mixed|null
+mixed
 ```
 
 ---
@@ -146,25 +144,6 @@ public get_event_class() : string
 ##### Summary
 
 Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
@@ -189,63 +168,6 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Contact-Verification-Request.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Contact-Verification-Request.md
@@ -19,11 +19,7 @@ This event indicates that a verification request was sent to the contact's email
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_email()](#method_get_email)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -34,6 +30,8 @@ This event indicates that a verification request was sent to the contact's email
 ### Details
 
 * File: [lib/event/contact/verification/request.php](../../lib/event/contact/verification/request.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
 * Uses Traits:
   * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Contact_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Contact-Trait.md)
@@ -115,7 +113,7 @@ Returns the contact object.
 ### get_data_by_key
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+final public get_data_by_key(string  key) : mixed
 ```
 
 ##### Summary
@@ -131,7 +129,7 @@ Gets the value of the event data specified by the given key.
 ##### Returns:
 
 ```
-array|mixed|null
+mixed
 ```
 
 ---
@@ -174,25 +172,6 @@ string
 
 ---
 
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_event_date"></a>
 ### get_event_date
 
@@ -208,63 +187,6 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Data-Trait.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Data-Trait.md
@@ -13,11 +13,7 @@ Trait that defines data access methods common to all event classes.
 * public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -81,7 +77,7 @@ Gets the date this event was acknowledged.
 ### get_data_by_key
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+final public get_data_by_key(string  key) : mixed
 ```
 
 ##### Summary
@@ -97,7 +93,7 @@ Gets the value of the event data specified by the given key.
 ##### Returns:
 
 ```
-array|mixed|null
+mixed
 ```
 
 ---
@@ -112,25 +108,6 @@ public get_event_class() : string
 ##### Summary
 
 Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
@@ -155,63 +132,6 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Delete-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Delete-Fail.md
@@ -13,29 +13,23 @@ This event is generated when a domain delete operation fails at the server.
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
-* public [get_data_by_key()](#method_get_data_by_key)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_domain()](#method_get_domain)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
 * public [get_event_errors()](#method_get_event_errors)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
-* public [get_id()](#method_get_id)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 
 ---
 
 ### Details
 
 * File: [lib/event/domain/delete/fail.php](../../lib/event/domain/delete/fail.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Error_Trait](../classes/Automattic-Domain-Services-Client-Event-Error-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
 * See Also:
@@ -45,71 +39,78 @@ This event is generated when a domain delete operation fails at the server.
 
 ## Methods
 
-<a id="method___construct"></a>
-### __construct
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
 
 ```
-final public __construct(array  data = []) : mixed
+public get_command_client_txn_id() : string
 ```
 
 ##### Summary
 
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-mixed
+string
 ```
 
 ---
 
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
 
 ```
-public get_acknowledged_date() : \DateTimeInterface|null
+public get_command_server_txn_id() : string
 ```
 
 ##### Summary
 
-Gets the date this event was acknowledged.
+Gets the server_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-\DateTimeInterface|null
+string
 ```
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
+<a id="method_get_command_status"></a>
+### get_command_status
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+public get_command_status() : int
 ```
 
 ##### Summary
 
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
+Gets the status code for this event
 
 ##### Returns:
 
 ```
-array|mixed|null
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -129,63 +130,6 @@ Returns the domain name object.
 
 ```
 \Automattic\Domain_Services_Client\Entity\Domain_Name
-```
-
----
-
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
 ```
 
 ---
@@ -223,142 +167,4 @@ The format will be an array of arrays:
 
 ```
 array[]
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Delete-Success.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Delete-Success.md
@@ -13,28 +13,22 @@ This event is generated when a domain delete operation succeeds at the server.
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
-* public [get_data_by_key()](#method_get_data_by_key)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_domain()](#method_get_domain)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
-* public [get_id()](#method_get_id)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 
 ---
 
 ### Details
 
 * File: [lib/event/domain/delete/success.php](../../lib/event/domain/delete/success.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
 * See Also:
   * [\Automattic\Domain_Services_Client\Command\Domain\Delete](../classes/Automattic-Domain-Services-Client-Command-Domain-Delete.md)
@@ -43,71 +37,78 @@ This event is generated when a domain delete operation succeeds at the server.
 
 ## Methods
 
-<a id="method___construct"></a>
-### __construct
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
 
 ```
-final public __construct(array  data = []) : mixed
+public get_command_client_txn_id() : string
 ```
 
 ##### Summary
 
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-mixed
+string
 ```
 
 ---
 
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
 
 ```
-public get_acknowledged_date() : \DateTimeInterface|null
+public get_command_server_txn_id() : string
 ```
 
 ##### Summary
 
-Gets the date this event was acknowledged.
+Gets the server_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-\DateTimeInterface|null
+string
 ```
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
+<a id="method_get_command_status"></a>
+### get_command_status
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+public get_command_status() : int
 ```
 
 ##### Summary
 
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
+Gets the status code for this event
 
 ##### Returns:
 
 ```
-array|mixed|null
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -127,199 +128,4 @@ Returns the domain name object.
 
 ```
 \Automattic\Domain_Services_Client\Entity\Domain_Name
-```
-
----
-
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Argp.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Argp.md
@@ -24,11 +24,7 @@ Domain entered the Auto-Renew Grace Period (ARGP) event
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -39,6 +35,8 @@ Domain entered the Auto-Renew Grace Period (ARGP) event
 ### Details
 
 * File: [lib/event/domain/notification/argp.php](../../lib/event/domain/notification/argp.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
 * Uses Traits:
   * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
@@ -116,7 +114,7 @@ Returns the date until which a domain is in ARGP, if available
 ### get_data_by_key
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+final public get_data_by_key(string  key) : mixed
 ```
 
 ##### Summary
@@ -132,7 +130,7 @@ Gets the value of the event data specified by the given key.
 ##### Returns:
 
 ```
-array|mixed|null
+mixed
 ```
 
 ---
@@ -175,25 +173,6 @@ string
 
 ---
 
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_event_date"></a>
 ### get_event_date
 
@@ -209,63 +188,6 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Auction.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Auction.md
@@ -32,11 +32,7 @@ Domain entered auction phase event
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -47,6 +43,8 @@ Domain entered auction phase event
 ### Details
 
 * File: [lib/event/domain/notification/auction.php](../../lib/event/domain/notification/auction.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
 * Uses Traits:
   * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
@@ -143,7 +141,7 @@ This is the date at which the domain will exit the current auction state
 ### get_data_by_key
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+final public get_data_by_key(string  key) : mixed
 ```
 
 ##### Summary
@@ -159,7 +157,7 @@ Gets the value of the event data specified by the given key.
 ##### Returns:
 
 ```
-array|mixed|null
+mixed
 ```
 
 ---
@@ -202,25 +200,6 @@ string
 
 ---
 
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_event_date"></a>
 ### get_event_date
 
@@ -236,63 +215,6 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Pending-Delete.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Pending-Delete.md
@@ -20,11 +20,7 @@ Domain expired event
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -36,6 +32,8 @@ Domain expired event
 ### Details
 
 * File: [lib/event/domain/notification/pending-delete.php](../../lib/event/domain/notification/pending-delete.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
 * Uses Traits:
   * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
@@ -92,7 +90,7 @@ Gets the date this event was acknowledged.
 ### get_data_by_key
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+final public get_data_by_key(string  key) : mixed
 ```
 
 ##### Summary
@@ -108,7 +106,7 @@ Gets the value of the event data specified by the given key.
 ##### Returns:
 
 ```
-array|mixed|null
+mixed
 ```
 
 ---
@@ -151,25 +149,6 @@ string
 
 ---
 
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_event_date"></a>
 ### get_event_date
 
@@ -185,63 +164,6 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Redemption.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Redemption.md
@@ -26,11 +26,7 @@ Domain entered redemption period event
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_object_id()](#method_get_object_id)
@@ -42,6 +38,8 @@ Domain entered redemption period event
 ### Details
 
 * File: [lib/event/domain/notification/redemption.php](../../lib/event/domain/notification/redemption.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
 * Uses Traits:
   * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
@@ -100,7 +98,7 @@ Gets the date this event was acknowledged.
 ### get_data_by_key
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+final public get_data_by_key(string  key) : mixed
 ```
 
 ##### Summary
@@ -116,7 +114,7 @@ Gets the value of the event data specified by the given key.
 ##### Returns:
 
 ```
-array|mixed|null
+mixed
 ```
 
 ---
@@ -159,25 +157,6 @@ string
 
 ---
 
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_event_date"></a>
 ### get_event_date
 
@@ -193,63 +172,6 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Suspended.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Suspended.md
@@ -21,11 +21,7 @@ Domain suspended event
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_info()](#method_get_info)
@@ -37,6 +33,8 @@ Domain suspended event
 ### Details
 
 * File: [lib/event/domain/notification/suspended.php](../../lib/event/domain/notification/suspended.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
 * Uses Traits:
   * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
@@ -95,7 +93,7 @@ Gets the date this event was acknowledged.
 ### get_data_by_key
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+final public get_data_by_key(string  key) : mixed
 ```
 
 ##### Summary
@@ -111,7 +109,7 @@ Gets the value of the event data specified by the given key.
 ##### Returns:
 
 ```
-array|mixed|null
+mixed
 ```
 
 ---
@@ -154,25 +152,6 @@ string
 
 ---
 
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_event_date"></a>
 ### get_event_date
 
@@ -188,63 +167,6 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Verified.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Notification-Verified.md
@@ -21,11 +21,7 @@ Domain verified event
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
 * public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
 * public [get_event_subclass()](#method_get_event_subclass)
 * public [get_id()](#method_get_id)
 * public [get_info()](#method_get_info)
@@ -37,6 +33,8 @@ Domain verified event
 ### Details
 
 * File: [lib/event/domain/notification/verified.php](../../lib/event/domain/notification/verified.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
 * Uses Traits:
   * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
@@ -95,7 +93,7 @@ Gets the date this event was acknowledged.
 ### get_data_by_key
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+final public get_data_by_key(string  key) : mixed
 ```
 
 ##### Summary
@@ -111,7 +109,7 @@ Gets the value of the event data specified by the given key.
 ##### Returns:
 
 ```
-array|mixed|null
+mixed
 ```
 
 ---
@@ -154,25 +152,6 @@ string
 
 ---
 
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_event_date"></a>
 ### get_event_date
 
@@ -188,63 +167,6 @@ Gets the date this event was generated.
 
 ```
 \DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Register-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Register-Fail.md
@@ -14,29 +14,23 @@ the event data.
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
-* public [get_data_by_key()](#method_get_data_by_key)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_domain()](#method_get_domain)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
 * public [get_event_errors()](#method_get_event_errors)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
-* public [get_id()](#method_get_id)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 
 ---
 
 ### Details
 
 * File: [lib/event/domain/register/fail.php](../../lib/event/domain/register/fail.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Error_Trait](../classes/Automattic-Domain-Services-Client-Event-Error-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
 * See Also:
@@ -46,71 +40,78 @@ the event data.
 
 ## Methods
 
-<a id="method___construct"></a>
-### __construct
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
 
 ```
-final public __construct(array  data = []) : mixed
+public get_command_client_txn_id() : string
 ```
 
 ##### Summary
 
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-mixed
+string
 ```
 
 ---
 
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
 
 ```
-public get_acknowledged_date() : \DateTimeInterface|null
+public get_command_server_txn_id() : string
 ```
 
 ##### Summary
 
-Gets the date this event was acknowledged.
+Gets the server_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-\DateTimeInterface|null
+string
 ```
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
+<a id="method_get_command_status"></a>
+### get_command_status
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+public get_command_status() : int
 ```
 
 ##### Summary
 
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
+Gets the status code for this event
 
 ##### Returns:
 
 ```
-array|mixed|null
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -130,63 +131,6 @@ Returns the domain name object.
 
 ```
 \Automattic\Domain_Services_Client\Entity\Domain_Name
-```
-
----
-
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
 ```
 
 ---
@@ -224,142 +168,4 @@ The format will be an array of arrays:
 
 ```
 array[]
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Register-Success.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Register-Success.md
@@ -13,25 +13,16 @@ This event is sent when a register operation succeeds.
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_agp_end_date()](#method_get_agp_end_date)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_contacts()](#method_get_contacts)
 * public [get_created_date()](#method_get_created_date)
-* public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
 * public [get_domain_status()](#method_get_domain_status)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
 * public [get_expiration_date()](#method_get_expiration_date)
-* public [get_id()](#method_get_id)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 * public [get_renewable_until()](#method_get_renewable_until)
 * public [get_unverified_contact_suspension_date()](#method_get_unverified_contact_suspension_date)
 
@@ -40,8 +31,11 @@ This event is sent when a register operation succeeds.
 ### Details
 
 * File: [lib/event/domain/register/success.php](../../lib/event/domain/register/success.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
 * See Also:
   * [\Automattic\Domain_Services_Client\Command\Domain\Register](../classes/Automattic-Domain-Services-Client-Command-Domain-Register.md)
@@ -49,50 +43,6 @@ This event is sent when a register operation succeeds.
 ---
 
 ## Methods
-
-<a id="method___construct"></a>
-### __construct
-
-```
-final public __construct(array  data = []) : mixed
-```
-
-##### Summary
-
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
-
-##### Returns:
-
-```
-mixed
-```
-
----
-
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
-
-```
-public get_acknowledged_date() : \DateTimeInterface|null
-```
-
-##### Summary
-
-Gets the date this event was acknowledged.
-
-##### Returns:
-
-```
-\DateTimeInterface|null
-```
-
----
 
 <a id="method_get_agp_end_date"></a>
 ### get_agp_end_date
@@ -115,6 +65,82 @@ Gets the date the domain will exit the Add Grace Period (AGP); null if no AGP is
 
 ```
 \DateTimeInterface|null
+```
+
+---
+
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
+
+```
+public get_command_client_txn_id() : string
+```
+
+##### Summary
+
+Gets the client_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
+
+```
+public get_command_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_command_status"></a>
+### get_command_status
+
+```
+public get_command_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -163,31 +189,6 @@ null|\DateTimeInterface
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
-
-```
-final public get_data_by_key(string  key) : array|mixed|null
-```
-
-##### Summary
-
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
-
-##### Returns:
-
-```
-array|mixed|null
-```
-
----
-
 <a id="method_get_domain"></a>
 ### get_domain
 
@@ -232,139 +233,6 @@ Gets the list of domain statuses
 
 ---
 
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_expiration_date"></a>
 ### get_expiration_date
 
@@ -380,68 +248,6 @@ Gets the domain expiration date
 
 ```
 null|\DateTimeInterface
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Renew-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Renew-Fail.md
@@ -14,29 +14,23 @@ Domain failed to renew event
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
-* public [get_data_by_key()](#method_get_data_by_key)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_domain()](#method_get_domain)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
 * public [get_event_errors()](#method_get_event_errors)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
-* public [get_id()](#method_get_id)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 
 ---
 
 ### Details
 
 * File: [lib/event/domain/renew/fail.php](../../lib/event/domain/renew/fail.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Error_Trait](../classes/Automattic-Domain-Services-Client-Event-Error-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
 * See Also:
@@ -46,71 +40,78 @@ Domain failed to renew event
 
 ## Methods
 
-<a id="method___construct"></a>
-### __construct
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
 
 ```
-final public __construct(array  data = []) : mixed
+public get_command_client_txn_id() : string
 ```
 
 ##### Summary
 
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-mixed
+string
 ```
 
 ---
 
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
 
 ```
-public get_acknowledged_date() : \DateTimeInterface|null
+public get_command_server_txn_id() : string
 ```
 
 ##### Summary
 
-Gets the date this event was acknowledged.
+Gets the server_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-\DateTimeInterface|null
+string
 ```
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
+<a id="method_get_command_status"></a>
+### get_command_status
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+public get_command_status() : int
 ```
 
 ##### Summary
 
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
+Gets the status code for this event
 
 ##### Returns:
 
 ```
-array|mixed|null
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -130,63 +131,6 @@ Returns the domain name object.
 
 ```
 \Automattic\Domain_Services_Client\Entity\Domain_Name
-```
-
----
-
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
 ```
 
 ---
@@ -224,142 +168,4 @@ The format will be an array of arrays:
 
 ```
 array[]
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Renew-Success.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Renew-Success.md
@@ -13,22 +13,13 @@ This event is generated when a domain renewal operation has completed successful
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
-* public [get_data_by_key()](#method_get_data_by_key)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_domain()](#method_get_domain)
 * public [get_domain_status()](#method_get_domain_status)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
 * public [get_expiration_date()](#method_get_expiration_date)
-* public [get_id()](#method_get_id)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 * public [get_renewable_until()](#method_get_renewable_until)
 
 ---
@@ -36,8 +27,11 @@ This event is generated when a domain renewal operation has completed successful
 ### Details
 
 * File: [lib/event/domain/renew/success.php](../../lib/event/domain/renew/success.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
 * See Also:
   * [\Automattic\Domain_Services_Client\Command\Domain\Renew](../classes/Automattic-Domain-Services-Client-Command-Domain-Renew.md)
@@ -46,71 +40,78 @@ This event is generated when a domain renewal operation has completed successful
 
 ## Methods
 
-<a id="method___construct"></a>
-### __construct
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
 
 ```
-final public __construct(array  data = []) : mixed
+public get_command_client_txn_id() : string
 ```
 
 ##### Summary
 
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-mixed
+string
 ```
 
 ---
 
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
 
 ```
-public get_acknowledged_date() : \DateTimeInterface|null
+public get_command_server_txn_id() : string
 ```
 
 ##### Summary
 
-Gets the date this event was acknowledged.
+Gets the server_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-\DateTimeInterface|null
+string
 ```
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
+<a id="method_get_command_status"></a>
+### get_command_status
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+public get_command_status() : int
 ```
 
 ##### Summary
 
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
+Gets the status code for this event
 
 ##### Returns:
 
 ```
-array|mixed|null
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -145,149 +146,10 @@ public get_domain_status() : \Automattic\Domain_Services_Client\Entity\Epp_Statu
 
 Returns the domain status after the renewal operation
 
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \Automattic\Domain_Services_Client\Exception\Entity\Invalid_Value_Exception |  |
-
 ##### Returns:
 
 ```
 \Automattic\Domain_Services_Client\Entity\Epp_Status_Codes
-```
-
----
-
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
 ```
 
 ---
@@ -307,68 +169,6 @@ Returns the domain expiration date after the renewal operation
 
 ```
 \DateTimeInterface|null
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Restore-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Restore-Fail.md
@@ -14,29 +14,23 @@ the event data.
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
-* public [get_data_by_key()](#method_get_data_by_key)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_domain()](#method_get_domain)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
 * public [get_event_errors()](#method_get_event_errors)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
-* public [get_id()](#method_get_id)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 
 ---
 
 ### Details
 
 * File: [lib/event/domain/restore/fail.php](../../lib/event/domain/restore/fail.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Error_Trait](../classes/Automattic-Domain-Services-Client-Event-Error-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
 * See Also:
@@ -46,71 +40,78 @@ the event data.
 
 ## Methods
 
-<a id="method___construct"></a>
-### __construct
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
 
 ```
-final public __construct(array  data = []) : mixed
+public get_command_client_txn_id() : string
 ```
 
 ##### Summary
 
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-mixed
+string
 ```
 
 ---
 
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
 
 ```
-public get_acknowledged_date() : \DateTimeInterface|null
+public get_command_server_txn_id() : string
 ```
 
 ##### Summary
 
-Gets the date this event was acknowledged.
+Gets the server_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-\DateTimeInterface|null
+string
 ```
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
+<a id="method_get_command_status"></a>
+### get_command_status
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+public get_command_status() : int
 ```
 
 ##### Summary
 
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
+Gets the status code for this event
 
 ##### Returns:
 
 ```
-array|mixed|null
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -130,63 +131,6 @@ Returns the domain name object.
 
 ```
 \Automattic\Domain_Services_Client\Entity\Domain_Name
-```
-
----
-
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
 ```
 
 ---
@@ -224,142 +168,4 @@ The format will be an array of arrays:
 
 ```
 array[]
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Restore-Success.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Restore-Success.md
@@ -13,22 +13,13 @@ This event is sent when a restore operation succeeds.
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
-* public [get_data_by_key()](#method_get_data_by_key)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_domain()](#method_get_domain)
 * public [get_domain_status()](#method_get_domain_status)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
 * public [get_expiration_date()](#method_get_expiration_date)
-* public [get_id()](#method_get_id)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 * public [get_renewable_until()](#method_get_renewable_until)
 
 ---
@@ -36,8 +27,11 @@ This event is sent when a restore operation succeeds.
 ### Details
 
 * File: [lib/event/domain/restore/success.php](../../lib/event/domain/restore/success.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
 * See Also:
   * [\Automattic\Domain_Services_Client\Command\Domain\Restore](../classes/Automattic-Domain-Services-Client-Command-Domain-Restore.md)
@@ -46,71 +40,78 @@ This event is sent when a restore operation succeeds.
 
 ## Methods
 
-<a id="method___construct"></a>
-### __construct
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
 
 ```
-final public __construct(array  data = []) : mixed
+public get_command_client_txn_id() : string
 ```
 
 ##### Summary
 
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-mixed
+string
 ```
 
 ---
 
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
 
 ```
-public get_acknowledged_date() : \DateTimeInterface|null
+public get_command_server_txn_id() : string
 ```
 
 ##### Summary
 
-Gets the date this event was acknowledged.
+Gets the server_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-\DateTimeInterface|null
+string
 ```
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
+<a id="method_get_command_status"></a>
+### get_command_status
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+public get_command_status() : int
 ```
 
 ##### Summary
 
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
+Gets the status code for this event
 
 ##### Returns:
 
 ```
-array|mixed|null
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -145,149 +146,10 @@ public get_domain_status() : \Automattic\Domain_Services_Client\Entity\Epp_Statu
 
 Gets the status of the domain immediately after the restore operation.
 
-##### Throws:
-
-| Type | Description |
-|------|-------------|
-| \Automattic\Domain_Services_Client\Exception\Entity\Invalid_Value_Exception |  |
-
 ##### Returns:
 
 ```
 \Automattic\Domain_Services_Client\Entity\Epp_Status_Codes
-```
-
----
-
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
 ```
 
 ---
@@ -307,68 +169,6 @@ Gets the expiration date of the domain after the restore operation.
 
 ```
 \DateTimeInterface|null
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Contacts-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Contacts-Fail.md
@@ -9,29 +9,23 @@ Event representing a `Domain\Set\Contacts` command failure
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
-* public [get_data_by_key()](#method_get_data_by_key)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_domain()](#method_get_domain)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
 * public [get_event_errors()](#method_get_event_errors)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
-* public [get_id()](#method_get_id)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 
 ---
 
 ### Details
 
 * File: [lib/event/domain/set/contacts/fail.php](../../lib/event/domain/set/contacts/fail.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Error_Trait](../classes/Automattic-Domain-Services-Client-Event-Error-Trait.md)
 * See Also:
@@ -41,71 +35,78 @@ Event representing a `Domain\Set\Contacts` command failure
 
 ## Methods
 
-<a id="method___construct"></a>
-### __construct
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
 
 ```
-final public __construct(array  data = []) : mixed
+public get_command_client_txn_id() : string
 ```
 
 ##### Summary
 
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-mixed
+string
 ```
 
 ---
 
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
 
 ```
-public get_acknowledged_date() : \DateTimeInterface|null
+public get_command_server_txn_id() : string
 ```
 
 ##### Summary
 
-Gets the date this event was acknowledged.
+Gets the server_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-\DateTimeInterface|null
+string
 ```
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
+<a id="method_get_command_status"></a>
+### get_command_status
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+public get_command_status() : int
 ```
 
 ##### Summary
 
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
+Gets the status code for this event
 
 ##### Returns:
 
 ```
-array|mixed|null
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -125,63 +126,6 @@ Returns the domain name object.
 
 ```
 \Automattic\Domain_Services_Client\Entity\Domain_Name
-```
-
----
-
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
 ```
 
 ---
@@ -219,142 +163,4 @@ The format will be an array of arrays:
 
 ```
 array[]
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Contacts-Success.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Contacts-Success.md
@@ -9,29 +9,23 @@ Event representing a `Domain\Set\Contacts` command success
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_contacts()](#method_get_contacts)
-* public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
-* public [get_id()](#method_get_id)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 
 ---
 
 ### Details
 
 * File: [lib/event/domain/set/contacts/success.php](../../lib/event/domain/set/contacts/success.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
 * See Also:
   * [\Automattic\Domain_Services_Client\Command\Domain\Set\Contacts](../classes/Automattic-Domain-Services-Client-Command-Domain-Set-Contacts.md)
@@ -40,46 +34,78 @@ Event representing a `Domain\Set\Contacts` command success
 
 ## Methods
 
-<a id="method___construct"></a>
-### __construct
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
 
 ```
-final public __construct(array  data = []) : mixed
+public get_command_client_txn_id() : string
 ```
 
 ##### Summary
 
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-mixed
+string
 ```
 
 ---
 
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
 
 ```
-public get_acknowledged_date() : \DateTimeInterface|null
+public get_command_server_txn_id() : string
 ```
 
 ##### Summary
 
-Gets the date this event was acknowledged.
+Gets the server_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-\DateTimeInterface|null
+string
+```
+
+---
+
+<a id="method_get_command_status"></a>
+### get_command_status
+
+```
+public get_command_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -109,31 +135,6 @@ Returns the domain contacts of the updated domain
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
-
-```
-final public get_data_by_key(string  key) : array|mixed|null
-```
-
-##### Summary
-
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
-
-##### Returns:
-
-```
-array|mixed|null
-```
-
----
-
 <a id="method_get_domain"></a>
 ### get_domain
 
@@ -149,199 +150,4 @@ Returns the domain name object.
 
 ```
 \Automattic\Domain_Services_Client\Entity\Domain_Name
-```
-
----
-
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Nameservers-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Nameservers-Fail.md
@@ -13,29 +13,23 @@ This event is generated when a name server update fails at the server.
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
-* public [get_data_by_key()](#method_get_data_by_key)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_domain()](#method_get_domain)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
 * public [get_event_errors()](#method_get_event_errors)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
-* public [get_id()](#method_get_id)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 
 ---
 
 ### Details
 
 * File: [lib/event/domain/set/nameservers/fail.php](../../lib/event/domain/set/nameservers/fail.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Error_Trait](../classes/Automattic-Domain-Services-Client-Event-Error-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
 * See Also:
@@ -45,71 +39,78 @@ This event is generated when a name server update fails at the server.
 
 ## Methods
 
-<a id="method___construct"></a>
-### __construct
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
 
 ```
-final public __construct(array  data = []) : mixed
+public get_command_client_txn_id() : string
 ```
 
 ##### Summary
 
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-mixed
+string
 ```
 
 ---
 
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
 
 ```
-public get_acknowledged_date() : \DateTimeInterface|null
+public get_command_server_txn_id() : string
 ```
 
 ##### Summary
 
-Gets the date this event was acknowledged.
+Gets the server_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-\DateTimeInterface|null
+string
 ```
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
+<a id="method_get_command_status"></a>
+### get_command_status
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+public get_command_status() : int
 ```
 
 ##### Summary
 
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
+Gets the status code for this event
 
 ##### Returns:
 
 ```
-array|mixed|null
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -129,63 +130,6 @@ Returns the domain name object.
 
 ```
 \Automattic\Domain_Services_Client\Entity\Domain_Name
-```
-
----
-
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
 ```
 
 ---
@@ -223,142 +167,4 @@ The format will be an array of arrays:
 
 ```
 array[]
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Nameservers-Success.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Nameservers-Success.md
@@ -14,29 +14,23 @@ Set name servers success event
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
-* public [get_data_by_key()](#method_get_data_by_key)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_domain()](#method_get_domain)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
-* public [get_id()](#method_get_id)
 * public [get_nameservers()](#method_get_nameservers)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 
 ---
 
 ### Details
 
 * File: [lib/event/domain/set/nameservers/success.php](../../lib/event/domain/set/nameservers/success.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
 * See Also:
   * [\Automattic\Domain_Services_Client\Command\Domain\Set\Nameservers](../classes/Automattic-Domain-Services-Client-Command-Domain-Set-Nameservers.md)
@@ -45,71 +39,78 @@ Set name servers success event
 
 ## Methods
 
-<a id="method___construct"></a>
-### __construct
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
 
 ```
-final public __construct(array  data = []) : mixed
+public get_command_client_txn_id() : string
 ```
 
 ##### Summary
 
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-mixed
+string
 ```
 
 ---
 
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
 
 ```
-public get_acknowledged_date() : \DateTimeInterface|null
+public get_command_server_txn_id() : string
 ```
 
 ##### Summary
 
-Gets the date this event was acknowledged.
+Gets the server_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-\DateTimeInterface|null
+string
 ```
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
+<a id="method_get_command_status"></a>
+### get_command_status
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+public get_command_status() : int
 ```
 
 ##### Summary
 
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
+Gets the status code for this event
 
 ##### Returns:
 
 ```
-array|mixed|null
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -129,158 +130,6 @@ Returns the domain name object.
 
 ```
 \Automattic\Domain_Services_Client\Entity\Domain_Name
-```
-
----
-
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
 ```
 
 ---
@@ -306,47 +155,4 @@ Returns the name servers that have been set at the registry.
 
 ```
 \Automattic\Domain_Services_Client\Entity\Nameservers
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Privacy-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Privacy-Fail.md
@@ -13,29 +13,23 @@ This event is generated when a privacy setting update fails at the server.
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
-* public [get_data_by_key()](#method_get_data_by_key)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_domain()](#method_get_domain)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
 * public [get_event_errors()](#method_get_event_errors)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
-* public [get_id()](#method_get_id)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 
 ---
 
 ### Details
 
 * File: [lib/event/domain/set/privacy/fail.php](../../lib/event/domain/set/privacy/fail.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Error_Trait](../classes/Automattic-Domain-Services-Client-Event-Error-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
 * See Also:
@@ -45,71 +39,78 @@ This event is generated when a privacy setting update fails at the server.
 
 ## Methods
 
-<a id="method___construct"></a>
-### __construct
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
 
 ```
-final public __construct(array  data = []) : mixed
+public get_command_client_txn_id() : string
 ```
 
 ##### Summary
 
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-mixed
+string
 ```
 
 ---
 
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
 
 ```
-public get_acknowledged_date() : \DateTimeInterface|null
+public get_command_server_txn_id() : string
 ```
 
 ##### Summary
 
-Gets the date this event was acknowledged.
+Gets the server_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-\DateTimeInterface|null
+string
 ```
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
+<a id="method_get_command_status"></a>
+### get_command_status
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+public get_command_status() : int
 ```
 
 ##### Summary
 
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
+Gets the status code for this event
 
 ##### Returns:
 
 ```
-array|mixed|null
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -129,63 +130,6 @@ Returns the domain name object.
 
 ```
 \Automattic\Domain_Services_Client\Entity\Domain_Name
-```
-
----
-
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
 ```
 
 ---
@@ -223,142 +167,4 @@ The format will be an array of arrays:
 
 ```
 array[]
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Privacy-Success.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Privacy-Success.md
@@ -14,20 +14,11 @@ Success event for a `Domain\Set\Privacy` command
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
-* public [get_data_by_key()](#method_get_data_by_key)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_domain()](#method_get_domain)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
-* public [get_id()](#method_get_id)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 * public [get_privacy_setting()](#method_get_privacy_setting)
 
 ---
@@ -35,8 +26,11 @@ Success event for a `Domain\Set\Privacy` command
 ### Details
 
 * File: [lib/event/domain/set/privacy/success.php](../../lib/event/domain/set/privacy/success.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
 * See Also:
   * [\Automattic\Domain_Services_Client\Command\Domain\Set\Privacy](../classes/Automattic-Domain-Services-Client-Command-Domain-Set-Privacy.md)
@@ -45,71 +39,78 @@ Success event for a `Domain\Set\Privacy` command
 
 ## Methods
 
-<a id="method___construct"></a>
-### __construct
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
 
 ```
-final public __construct(array  data = []) : mixed
+public get_command_client_txn_id() : string
 ```
 
 ##### Summary
 
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-mixed
+string
 ```
 
 ---
 
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
 
 ```
-public get_acknowledged_date() : \DateTimeInterface|null
+public get_command_server_txn_id() : string
 ```
 
 ##### Summary
 
-Gets the date this event was acknowledged.
+Gets the server_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-\DateTimeInterface|null
+string
 ```
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
+<a id="method_get_command_status"></a>
+### get_command_status
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+public get_command_status() : int
 ```
 
 ##### Summary
 
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
+Gets the status code for this event
 
 ##### Returns:
 
 ```
-array|mixed|null
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -129,201 +130,6 @@ Returns the domain name object.
 
 ```
 \Automattic\Domain_Services_Client\Entity\Domain_Name
-```
-
----
-
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Transferlock-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Transferlock-Fail.md
@@ -9,29 +9,23 @@ Fail event for `Domain\Set\TransferLock` command
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
-* public [get_data_by_key()](#method_get_data_by_key)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_domain()](#method_get_domain)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
 * public [get_event_errors()](#method_get_event_errors)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
-* public [get_id()](#method_get_id)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 
 ---
 
 ### Details
 
 * File: [lib/event/domain/set/transferlock/fail.php](../../lib/event/domain/set/transferlock/fail.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Error_Trait](../classes/Automattic-Domain-Services-Client-Event-Error-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
 * See Also:
@@ -41,71 +35,78 @@ Fail event for `Domain\Set\TransferLock` command
 
 ## Methods
 
-<a id="method___construct"></a>
-### __construct
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
 
 ```
-final public __construct(array  data = []) : mixed
+public get_command_client_txn_id() : string
 ```
 
 ##### Summary
 
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-mixed
+string
 ```
 
 ---
 
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
 
 ```
-public get_acknowledged_date() : \DateTimeInterface|null
+public get_command_server_txn_id() : string
 ```
 
 ##### Summary
 
-Gets the date this event was acknowledged.
+Gets the server_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-\DateTimeInterface|null
+string
 ```
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
+<a id="method_get_command_status"></a>
+### get_command_status
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+public get_command_status() : int
 ```
 
 ##### Summary
 
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
+Gets the status code for this event
 
 ##### Returns:
 
 ```
-array|mixed|null
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -125,63 +126,6 @@ Returns the domain name object.
 
 ```
 \Automattic\Domain_Services_Client\Entity\Domain_Name
-```
-
----
-
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
 ```
 
 ---
@@ -219,142 +163,4 @@ The format will be an array of arrays:
 
 ```
 array[]
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Transferlock-Success.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Set-Transferlock-Success.md
@@ -9,20 +9,11 @@ Success event for `Domain\Set\TransferLock` command
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
-* public [get_data_by_key()](#method_get_data_by_key)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_domain()](#method_get_domain)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
-* public [get_id()](#method_get_id)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 * public [is_locked()](#method_is_locked)
 
 ---
@@ -30,8 +21,11 @@ Success event for `Domain\Set\TransferLock` command
 ### Details
 
 * File: [lib/event/domain/set/transferlock/success.php](../../lib/event/domain/set/transferlock/success.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
 * See Also:
   * [\Automattic\Domain_Services_Client\Command\Domain\Set\Transferlock](../classes/Automattic-Domain-Services-Client-Command-Domain-Set-Transferlock.md)
@@ -40,71 +34,78 @@ Success event for `Domain\Set\TransferLock` command
 
 ## Methods
 
-<a id="method___construct"></a>
-### __construct
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
 
 ```
-final public __construct(array  data = []) : mixed
+public get_command_client_txn_id() : string
 ```
 
 ##### Summary
 
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
+Gets the client_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-mixed
+string
 ```
 
 ---
 
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
 
 ```
-public get_acknowledged_date() : \DateTimeInterface|null
+public get_command_server_txn_id() : string
 ```
 
 ##### Summary
 
-Gets the date this event was acknowledged.
+Gets the server_txn_id from the command related to this event, if any
 
 ##### Returns:
 
 ```
-\DateTimeInterface|null
+string
 ```
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
+<a id="method_get_command_status"></a>
+### get_command_status
 
 ```
-final public get_data_by_key(string  key) : array|mixed|null
+public get_command_status() : int
 ```
 
 ##### Summary
 
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
+Gets the status code for this event
 
 ##### Returns:
 
 ```
-array|mixed|null
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -124,201 +125,6 @@ Returns the domain name object.
 
 ```
 \Automattic\Domain_Services_Client\Entity\Domain_Name
-```
-
----
-
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-In-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-In-Fail.md
@@ -15,23 +15,14 @@ Inbound domain transfer failure event
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_auto_nack()](#method_get_auto_nack)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_current_registrar()](#method_get_current_registrar)
-* public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
 * public [get_execute_date()](#method_get_execute_date)
-* public [get_id()](#method_get_id)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 * public [get_request_date()](#method_get_request_date)
 * public [get_requesting_registrar()](#method_get_requesting_registrar)
 * public [get_transfer_status()](#method_get_transfer_status)
@@ -41,58 +32,17 @@ Inbound domain transfer failure event
 ### Details
 
 * File: [lib/event/domain/transfer/in/fail.php](../../lib/event/domain/transfer/in/fail.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Transfer_Trait](../classes/Automattic-Domain-Services-Client-Event-Transfer-Trait.md)
 
 ---
 
 ## Methods
-
-<a id="method___construct"></a>
-### __construct
-
-```
-final public __construct(array  data = []) : mixed
-```
-
-##### Summary
-
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
-
-##### Returns:
-
-```
-mixed
-```
-
----
-
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
-
-```
-public get_acknowledged_date() : \DateTimeInterface|null
-```
-
-##### Summary
-
-Gets the date this event was acknowledged.
-
-##### Returns:
-
-```
-\DateTimeInterface|null
-```
-
----
 
 <a id="method_get_auto_nack"></a>
 ### get_auto_nack
@@ -109,6 +59,82 @@ Gets whether the domain transfer associated with the event was automatically rej
 
 ```
 bool|null
+```
+
+---
+
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
+
+```
+public get_command_client_txn_id() : string
+```
+
+##### Summary
+
+Gets the client_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
+
+```
+public get_command_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_command_status"></a>
+### get_command_status
+
+```
+public get_command_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -132,31 +158,6 @@ string|null
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
-
-```
-final public get_data_by_key(string  key) : array|mixed|null
-```
-
-##### Summary
-
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
-
-##### Returns:
-
-```
-array|mixed|null
-```
-
----
-
 <a id="method_get_domain"></a>
 ### get_domain
 
@@ -176,139 +177,6 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_execute_date"></a>
 ### get_execute_date
 
@@ -324,68 +192,6 @@ Gets the date the transfer was executed.
 
 ```
 \DateTimeImmutable|null
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-In-Pending.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-In-Pending.md
@@ -13,23 +13,14 @@ This event is generated when a domain transfer from another registrar to the res
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_auto_nack()](#method_get_auto_nack)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_current_registrar()](#method_get_current_registrar)
-* public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
 * public [get_execute_date()](#method_get_execute_date)
-* public [get_id()](#method_get_id)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 * public [get_request_date()](#method_get_request_date)
 * public [get_requesting_registrar()](#method_get_requesting_registrar)
 * public [get_transfer_status()](#method_get_transfer_status)
@@ -39,58 +30,17 @@ This event is generated when a domain transfer from another registrar to the res
 ### Details
 
 * File: [lib/event/domain/transfer/in/pending.php](../../lib/event/domain/transfer/in/pending.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Transfer_Trait](../classes/Automattic-Domain-Services-Client-Event-Transfer-Trait.md)
 
 ---
 
 ## Methods
-
-<a id="method___construct"></a>
-### __construct
-
-```
-final public __construct(array  data = []) : mixed
-```
-
-##### Summary
-
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
-
-##### Returns:
-
-```
-mixed
-```
-
----
-
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
-
-```
-public get_acknowledged_date() : \DateTimeInterface|null
-```
-
-##### Summary
-
-Gets the date this event was acknowledged.
-
-##### Returns:
-
-```
-\DateTimeInterface|null
-```
-
----
 
 <a id="method_get_auto_nack"></a>
 ### get_auto_nack
@@ -107,6 +57,82 @@ Gets whether the domain transfer associated with the event was automatically rej
 
 ```
 bool|null
+```
+
+---
+
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
+
+```
+public get_command_client_txn_id() : string
+```
+
+##### Summary
+
+Gets the client_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
+
+```
+public get_command_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_command_status"></a>
+### get_command_status
+
+```
+public get_command_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -130,31 +156,6 @@ string|null
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
-
-```
-final public get_data_by_key(string  key) : array|mixed|null
-```
-
-##### Summary
-
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
-
-##### Returns:
-
-```
-array|mixed|null
-```
-
----
-
 <a id="method_get_domain"></a>
 ### get_domain
 
@@ -174,139 +175,6 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_execute_date"></a>
 ### get_execute_date
 
@@ -322,68 +190,6 @@ Gets the date the transfer was executed.
 
 ```
 \DateTimeImmutable|null
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-In-Success.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-In-Success.md
@@ -13,23 +13,14 @@ This event is generated when a domain transfer from another registrar to the res
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_auto_nack()](#method_get_auto_nack)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_current_registrar()](#method_get_current_registrar)
-* public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
 * public [get_execute_date()](#method_get_execute_date)
-* public [get_id()](#method_get_id)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 * public [get_request_date()](#method_get_request_date)
 * public [get_requesting_registrar()](#method_get_requesting_registrar)
 * public [get_transfer_status()](#method_get_transfer_status)
@@ -39,58 +30,17 @@ This event is generated when a domain transfer from another registrar to the res
 ### Details
 
 * File: [lib/event/domain/transfer/in/success.php](../../lib/event/domain/transfer/in/success.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Transfer_Trait](../classes/Automattic-Domain-Services-Client-Event-Transfer-Trait.md)
 
 ---
 
 ## Methods
-
-<a id="method___construct"></a>
-### __construct
-
-```
-final public __construct(array  data = []) : mixed
-```
-
-##### Summary
-
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
-
-##### Returns:
-
-```
-mixed
-```
-
----
-
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
-
-```
-public get_acknowledged_date() : \DateTimeInterface|null
-```
-
-##### Summary
-
-Gets the date this event was acknowledged.
-
-##### Returns:
-
-```
-\DateTimeInterface|null
-```
-
----
 
 <a id="method_get_auto_nack"></a>
 ### get_auto_nack
@@ -107,6 +57,82 @@ Gets whether the domain transfer associated with the event was automatically rej
 
 ```
 bool|null
+```
+
+---
+
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
+
+```
+public get_command_client_txn_id() : string
+```
+
+##### Summary
+
+Gets the client_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
+
+```
+public get_command_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_command_status"></a>
+### get_command_status
+
+```
+public get_command_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -130,31 +156,6 @@ string|null
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
-
-```
-final public get_data_by_key(string  key) : array|mixed|null
-```
-
-##### Summary
-
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
-
-##### Returns:
-
-```
-array|mixed|null
-```
-
----
-
 <a id="method_get_domain"></a>
 ### get_domain
 
@@ -174,139 +175,6 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_execute_date"></a>
 ### get_execute_date
 
@@ -322,68 +190,6 @@ Gets the date the transfer was executed.
 
 ```
 \DateTimeImmutable|null
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-Out-Fail.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-Out-Fail.md
@@ -14,23 +14,14 @@ Outbound domain transfer failure event
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_auto_nack()](#method_get_auto_nack)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_current_registrar()](#method_get_current_registrar)
-* public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
 * public [get_execute_date()](#method_get_execute_date)
-* public [get_id()](#method_get_id)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 * public [get_request_date()](#method_get_request_date)
 * public [get_requesting_registrar()](#method_get_requesting_registrar)
 * public [get_transfer_status()](#method_get_transfer_status)
@@ -40,58 +31,17 @@ Outbound domain transfer failure event
 ### Details
 
 * File: [lib/event/domain/transfer/out/fail.php](../../lib/event/domain/transfer/out/fail.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Transfer_Trait](../classes/Automattic-Domain-Services-Client-Event-Transfer-Trait.md)
 
 ---
 
 ## Methods
-
-<a id="method___construct"></a>
-### __construct
-
-```
-final public __construct(array  data = []) : mixed
-```
-
-##### Summary
-
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
-
-##### Returns:
-
-```
-mixed
-```
-
----
-
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
-
-```
-public get_acknowledged_date() : \DateTimeInterface|null
-```
-
-##### Summary
-
-Gets the date this event was acknowledged.
-
-##### Returns:
-
-```
-\DateTimeInterface|null
-```
-
----
 
 <a id="method_get_auto_nack"></a>
 ### get_auto_nack
@@ -108,6 +58,82 @@ Gets whether the domain transfer associated with the event was automatically rej
 
 ```
 bool|null
+```
+
+---
+
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
+
+```
+public get_command_client_txn_id() : string
+```
+
+##### Summary
+
+Gets the client_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
+
+```
+public get_command_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_command_status"></a>
+### get_command_status
+
+```
+public get_command_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -131,31 +157,6 @@ string|null
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
-
-```
-final public get_data_by_key(string  key) : array|mixed|null
-```
-
-##### Summary
-
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
-
-##### Returns:
-
-```
-array|mixed|null
-```
-
----
-
 <a id="method_get_domain"></a>
 ### get_domain
 
@@ -175,139 +176,6 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_execute_date"></a>
 ### get_execute_date
 
@@ -323,68 +191,6 @@ Gets the date the transfer was executed.
 
 ```
 \DateTimeImmutable|null
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-Out-Pending.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-Out-Pending.md
@@ -13,23 +13,14 @@ This event is generated when a domain transfer to another registrar is started.
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_auto_nack()](#method_get_auto_nack)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_current_registrar()](#method_get_current_registrar)
-* public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
 * public [get_execute_date()](#method_get_execute_date)
-* public [get_id()](#method_get_id)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 * public [get_request_date()](#method_get_request_date)
 * public [get_requesting_registrar()](#method_get_requesting_registrar)
 * public [get_transfer_status()](#method_get_transfer_status)
@@ -39,58 +30,17 @@ This event is generated when a domain transfer to another registrar is started.
 ### Details
 
 * File: [lib/event/domain/transfer/out/pending.php](../../lib/event/domain/transfer/out/pending.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Transfer_Trait](../classes/Automattic-Domain-Services-Client-Event-Transfer-Trait.md)
 
 ---
 
 ## Methods
-
-<a id="method___construct"></a>
-### __construct
-
-```
-final public __construct(array  data = []) : mixed
-```
-
-##### Summary
-
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
-
-##### Returns:
-
-```
-mixed
-```
-
----
-
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
-
-```
-public get_acknowledged_date() : \DateTimeInterface|null
-```
-
-##### Summary
-
-Gets the date this event was acknowledged.
-
-##### Returns:
-
-```
-\DateTimeInterface|null
-```
-
----
 
 <a id="method_get_auto_nack"></a>
 ### get_auto_nack
@@ -107,6 +57,82 @@ Gets whether the domain transfer associated with the event was automatically rej
 
 ```
 bool|null
+```
+
+---
+
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
+
+```
+public get_command_client_txn_id() : string
+```
+
+##### Summary
+
+Gets the client_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
+
+```
+public get_command_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_command_status"></a>
+### get_command_status
+
+```
+public get_command_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -130,31 +156,6 @@ string|null
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
-
-```
-final public get_data_by_key(string  key) : array|mixed|null
-```
-
-##### Summary
-
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
-
-##### Returns:
-
-```
-array|mixed|null
-```
-
----
-
 <a id="method_get_domain"></a>
 ### get_domain
 
@@ -174,139 +175,6 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_execute_date"></a>
 ### get_execute_date
 
@@ -322,68 +190,6 @@ Gets the date the transfer was executed.
 
 ```
 \DateTimeImmutable|null
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-Out-Success.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-Out-Success.md
@@ -13,23 +13,14 @@ This event is generated when a domain transfer to another registrar is successfu
 
 ### Methods
 
-* public [__construct()](#method___construct)
-* public [get_acknowledged_date()](#method_get_acknowledged_date)
 * public [get_auto_nack()](#method_get_auto_nack)
+* public [get_command_client_txn_id()](#method_get_command_client_txn_id)
+* public [get_command_server_txn_id()](#method_get_command_server_txn_id)
+* public [get_command_status()](#method_get_command_status)
+* public [get_command_status_description()](#method_get_command_status_description)
 * public [get_current_registrar()](#method_get_current_registrar)
-* public [get_data_by_key()](#method_get_data_by_key)
 * public [get_domain()](#method_get_domain)
-* public [get_event_class()](#method_get_event_class)
-* public [get_event_client_txn_id()](#method_get_event_client_txn_id)
-* public [get_event_date()](#method_get_event_date)
-* public [get_event_server_txn_id()](#method_get_event_server_txn_id)
-* public [get_event_status()](#method_get_event_status)
-* public [get_event_status_description()](#method_get_event_status_description)
-* public [get_event_subclass()](#method_get_event_subclass)
 * public [get_execute_date()](#method_get_execute_date)
-* public [get_id()](#method_get_id)
-* public [get_object_id()](#method_get_object_id)
-* public [get_object_type()](#method_get_object_type)
 * public [get_request_date()](#method_get_request_date)
 * public [get_requesting_registrar()](#method_get_requesting_registrar)
 * public [get_transfer_status()](#method_get_transfer_status)
@@ -39,58 +30,17 @@ This event is generated when a domain transfer to another registrar is successfu
 ### Details
 
 * File: [lib/event/domain/transfer/out/success.php](../../lib/event/domain/transfer/out/success.php)
+* Implements:
+  * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
 * Uses Traits:
-  * [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Transfer_Trait](../classes/Automattic-Domain-Services-Client-Event-Transfer-Trait.md)
 
 ---
 
 ## Methods
-
-<a id="method___construct"></a>
-### __construct
-
-```
-final public __construct(array  data = []) : mixed
-```
-
-##### Summary
-
-Constructs an event object
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$data** | array | [] |
-
-##### Returns:
-
-```
-mixed
-```
-
----
-
-<a id="method_get_acknowledged_date"></a>
-### get_acknowledged_date
-
-```
-public get_acknowledged_date() : \DateTimeInterface|null
-```
-
-##### Summary
-
-Gets the date this event was acknowledged.
-
-##### Returns:
-
-```
-\DateTimeInterface|null
-```
-
----
 
 <a id="method_get_auto_nack"></a>
 ### get_auto_nack
@@ -107,6 +57,82 @@ Gets whether the domain transfer associated with the event was automatically rej
 
 ```
 bool|null
+```
+
+---
+
+<a id="method_get_command_client_txn_id"></a>
+### get_command_client_txn_id
+
+```
+public get_command_client_txn_id() : string
+```
+
+##### Summary
+
+Gets the client_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_command_server_txn_id"></a>
+### get_command_server_txn_id
+
+```
+public get_command_server_txn_id() : string
+```
+
+##### Summary
+
+Gets the server_txn_id from the command related to this event, if any
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_command_status"></a>
+### get_command_status
+
+```
+public get_command_status() : int
+```
+
+##### Summary
+
+Gets the status code for this event
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_command_status_description"></a>
+### get_command_status_description
+
+```
+public get_command_status_description() : string
+```
+
+##### Summary
+
+Gets a description of the status code meaning
+
+##### Returns:
+
+```
+string
 ```
 
 ---
@@ -130,31 +156,6 @@ string|null
 
 ---
 
-<a id="method_get_data_by_key"></a>
-### get_data_by_key
-
-```
-final public get_data_by_key(string  key) : array|mixed|null
-```
-
-##### Summary
-
-Gets the value of the event data specified by the given key.
-
-##### Parameters:
-
-| Name | Type | Default |
-|------|------|---------|
-| **$key** | string |  |
-
-##### Returns:
-
-```
-array|mixed|null
-```
-
----
-
 <a id="method_get_domain"></a>
 ### get_domain
 
@@ -174,139 +175,6 @@ Returns the domain name object.
 
 ---
 
-<a id="method_get_event_class"></a>
-### get_event_class
-
-```
-public get_event_class() : string
-```
-
-##### Summary
-
-Gets the event class
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_client_txn_id"></a>
-### get_event_client_txn_id
-
-```
-public get_event_client_txn_id() : string
-```
-
-##### Summary
-
-Gets the client_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_date"></a>
-### get_event_date
-
-```
-public get_event_date() : \DateTimeInterface
-```
-
-##### Summary
-
-Gets the date this event was generated.
-
-##### Returns:
-
-```
-\DateTimeInterface
-```
-
----
-
-<a id="method_get_event_server_txn_id"></a>
-### get_event_server_txn_id
-
-```
-public get_event_server_txn_id() : string
-```
-
-##### Summary
-
-Gets the server_txn_id from the command related to this event, if any
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_status"></a>
-### get_event_status
-
-```
-public get_event_status() : int
-```
-
-##### Summary
-
-Gets the status code for this event
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_event_status_description"></a>
-### get_event_status_description
-
-```
-public get_event_status_description() : string
-```
-
-##### Summary
-
-Gets a description of the status code meaning
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_event_subclass"></a>
-### get_event_subclass
-
-```
-public get_event_subclass() : string
-```
-
-##### Summary
-
-Gets the event subclass
-
-##### Returns:
-
-```
-string
-```
-
----
-
 <a id="method_get_execute_date"></a>
 ### get_execute_date
 
@@ -322,68 +190,6 @@ Gets the date the transfer was executed.
 
 ```
 \DateTimeImmutable|null
-```
-
----
-
-<a id="method_get_id"></a>
-### get_id
-
-```
-public get_id() : int
-```
-
-##### Summary
-
-Gets the event ID
-
-##### Returns:
-
-```
-int
-```
-
----
-
-<a id="method_get_object_id"></a>
-### get_object_id
-
-```
-public get_object_id() : string
-```
-
-##### Summary
-
-Gets the ID of the object that this event references.
-
-##### Description
-
-- The contact ID for a contact object type
-- The domain name for a domain object type
-
-##### Returns:
-
-```
-string
-```
-
----
-
-<a id="method_get_object_type"></a>
-### get_object_type
-
-```
-public get_object_type() : string
-```
-
-##### Summary
-
-Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
-
-##### Returns:
-
-```
-string
 ```
 
 ---

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Event-Interface.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Event-Interface.md
@@ -1,0 +1,293 @@
+# Interface: Event_Interface
+## Summary:
+
+An interface used by all event classes.
+
+
+---
+
+### Constants
+* public [KEY_ID](#constant_KEY_ID)
+* public [KEY_OBJECT_ID](#constant_KEY_OBJECT_ID)
+* public [KEY_OBJECT_TYPE](#constant_KEY_OBJECT_TYPE)
+* public [KEY_EVENT_DATE](#constant_KEY_EVENT_DATE)
+* public [KEY_ACKNOWLEDGED_DATE](#constant_KEY_ACKNOWLEDGED_DATE)
+* public [KEY_EVENT_CLASS](#constant_KEY_EVENT_CLASS)
+* public [KEY_EVENT_SUBCLASS](#constant_KEY_EVENT_SUBCLASS)
+* public [KEY_EVENT_ERRORS](#constant_KEY_EVENT_ERRORS)
+* public [KEY_COMMAND_STATUS](#constant_KEY_COMMAND_STATUS)
+* public [KEY_COMMAND_STATUS_DESCRIPTION](#constant_KEY_COMMAND_STATUS_DESCRIPTION)
+* public [KEY_COMMAND_CLIENT_TNX_ID](#constant_KEY_COMMAND_CLIENT_TNX_ID)
+* public [KEY_COMMAND_SERVER_TNX_ID](#constant_KEY_COMMAND_SERVER_TNX_ID)
+
+---
+
+### Methods
+
+* public [get_acknowledged_date()](#method_get_acknowledged_date)
+* public [get_data_by_key()](#method_get_data_by_key)
+* public [get_event_class()](#method_get_event_class)
+* public [get_event_date()](#method_get_event_date)
+* public [get_event_subclass()](#method_get_event_subclass)
+* public [get_id()](#method_get_id)
+* public [get_object_id()](#method_get_object_id)
+* public [get_object_type()](#method_get_object_type)
+
+---
+
+### Details
+
+* File: [lib/event/event-interface.php](../../lib/event/event-interface.php)
+
+---
+
+## Constants
+<a id="constant_KEY_ID"></a>
+###### KEY_ID
+```
+KEY_ID = 'id'
+```
+
+
+<a id="constant_KEY_OBJECT_ID"></a>
+###### KEY_OBJECT_ID
+```
+KEY_OBJECT_ID = 'object_id'
+```
+
+
+<a id="constant_KEY_OBJECT_TYPE"></a>
+###### KEY_OBJECT_TYPE
+```
+KEY_OBJECT_TYPE = 'object_type'
+```
+
+
+<a id="constant_KEY_EVENT_DATE"></a>
+###### KEY_EVENT_DATE
+```
+KEY_EVENT_DATE = 'event_date'
+```
+
+
+<a id="constant_KEY_ACKNOWLEDGED_DATE"></a>
+###### KEY_ACKNOWLEDGED_DATE
+```
+KEY_ACKNOWLEDGED_DATE = 'acknowledged_date'
+```
+
+
+<a id="constant_KEY_EVENT_CLASS"></a>
+###### KEY_EVENT_CLASS
+```
+KEY_EVENT_CLASS = 'event_class'
+```
+
+
+<a id="constant_KEY_EVENT_SUBCLASS"></a>
+###### KEY_EVENT_SUBCLASS
+```
+KEY_EVENT_SUBCLASS = 'event_subclass'
+```
+
+
+<a id="constant_KEY_EVENT_ERRORS"></a>
+###### KEY_EVENT_ERRORS
+```
+KEY_EVENT_ERRORS = 'event_data.errors'
+```
+
+
+<a id="constant_KEY_COMMAND_STATUS"></a>
+###### KEY_COMMAND_STATUS
+```
+KEY_COMMAND_STATUS = 'event_data.status'
+```
+
+
+<a id="constant_KEY_COMMAND_STATUS_DESCRIPTION"></a>
+###### KEY_COMMAND_STATUS_DESCRIPTION
+```
+KEY_COMMAND_STATUS_DESCRIPTION = 'event_data.status_description'
+```
+
+
+<a id="constant_KEY_COMMAND_CLIENT_TNX_ID"></a>
+###### KEY_COMMAND_CLIENT_TNX_ID
+```
+KEY_COMMAND_CLIENT_TNX_ID = 'event_data.client_tnx_id'
+```
+
+
+<a id="constant_KEY_COMMAND_SERVER_TNX_ID"></a>
+###### KEY_COMMAND_SERVER_TNX_ID
+```
+KEY_COMMAND_SERVER_TNX_ID = 'event_data.server_tnx_id'
+```
+
+
+
+---
+
+## Methods
+
+<a id="method_get_acknowledged_date"></a>
+### get_acknowledged_date
+
+```
+public get_acknowledged_date() : \DateTimeInterface|null
+```
+
+##### Summary
+
+Gets the date this event was acknowledged.
+
+##### Returns:
+
+```
+\DateTimeInterface|null
+```
+
+---
+
+<a id="method_get_data_by_key"></a>
+### get_data_by_key
+
+```
+public get_data_by_key(string  key) : mixed
+```
+
+##### Summary
+
+Gets the value of the event data specified by the given key.
+
+##### Parameters:
+
+| Name | Type | Default |
+|------|------|---------|
+| **$key** | string |  |
+
+##### Returns:
+
+```
+mixed
+```
+
+---
+
+<a id="method_get_event_class"></a>
+### get_event_class
+
+```
+public get_event_class() : string
+```
+
+##### Summary
+
+Gets the event class
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_event_date"></a>
+### get_event_date
+
+```
+public get_event_date() : \DateTimeInterface
+```
+
+##### Summary
+
+Gets the date this event was generated.
+
+##### Returns:
+
+```
+\DateTimeInterface
+```
+
+---
+
+<a id="method_get_event_subclass"></a>
+### get_event_subclass
+
+```
+public get_event_subclass() : string
+```
+
+##### Summary
+
+Gets the event subclass
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_id"></a>
+### get_id
+
+```
+public get_id() : int
+```
+
+##### Summary
+
+Gets the event ID
+
+##### Returns:
+
+```
+int
+```
+
+---
+
+<a id="method_get_object_id"></a>
+### get_object_id
+
+```
+public get_object_id() : string
+```
+
+##### Summary
+
+Gets the ID of the object that this event references.
+
+##### Description
+
+- The contact ID for a contact object type
+- The domain name for a domain object type
+
+##### Returns:
+
+```
+string
+```
+
+---
+
+<a id="method_get_object_type"></a>
+### get_object_type
+
+```
+public get_object_type() : string
+```
+
+##### Summary
+
+Gets the type of object that this event references (ex. &#039;domain&#039; or &#039;contact&#039;)
+
+##### Returns:
+
+```
+string
+```

--- a/docs/classes/Automattic-Domain-Services-Client-Response-Event-Enumerate.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Response-Event-Enumerate.md
@@ -271,7 +271,7 @@ public get_total_count() : int
 
 ##### Summary
 
-Gets the total number of events returned
+Gets the total number of unacknowledged events that exist for the reseller that called the command
 
 ##### Returns:
 

--- a/docs/namespaces/automattic-domain-services-client-event.md
+++ b/docs/namespaces/automattic-domain-services-client-event.md
@@ -9,8 +9,17 @@
 
 | Name | Summary |
 |------|---------|
+| [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md) | Used by all events resulting from running an asynchronous command |
 | [\Automattic\Domain_Services_Client\Event\Data_Trait](../classes/Automattic-Domain-Services-Client-Event-Data-Trait.md) | Trait that defines data access methods common to all event classes. |
 | [\Automattic\Domain_Services_Client\Event\Error_Trait](../classes/Automattic-Domain-Services-Client-Event-Error-Trait.md) | Trait that specifies methods common to all error event classes. |
 | [\Automattic\Domain_Services_Client\Event\Object_Type_Contact_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Contact-Trait.md) | Trait for objects that are associated with a contact. |
 | [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md) | Trait for objects that are associated with a domain. |
 | [\Automattic\Domain_Services_Client\Event\Transfer_Trait](../classes/Automattic-Domain-Services-Client-Event-Transfer-Trait.md) | Trait that adds transfer-related methods to an event. |
+
+
+### Interfaces
+
+| Name | Summary |
+|------|---------|
+| [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md) | Implemented by all events resulting from running an asynchronous command |
+| [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md) | An interface used by all event classes. |

--- a/lib/event/async-command-related-interface.php
+++ b/lib/event/async-command-related-interface.php
@@ -18,6 +18,9 @@
 
 namespace Automattic\Domain_Services_Client\Event;
 
+/**
+ * Implemented by all events resulting from running an asynchronous command
+ */
 interface Async_Command_Related_Interface {
 	/**
 	 * Gets the status code for this event

--- a/lib/event/async-command-related-interface.php
+++ b/lib/event/async-command-related-interface.php
@@ -1,0 +1,49 @@
+<?php declare( strict_types=1 );
+/*
+ * Copyright (c) 2022 Automattic, Inc.
+ *
+ * This file is part of the Automattic Domain Services Client library.
+ *
+ * The Automattic Domain Services Client library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program;
+ * if not, see https://www.gnu.org/licenses.
+ */
+
+namespace Automattic\Domain_Services_Client\Event;
+
+interface Async_Command_Related_Interface {
+	/**
+	 * Gets the status code for this event
+	 *
+	 * @return int
+	 */
+	public function get_command_status(): ?int;
+
+	/**
+	 * Gets a description of the status code meaning
+	 *
+	 * @return string
+	 */
+	public function get_command_status_description(): ?string;
+
+	/**
+	 * Gets the client_txn_id from the command related to this event, if any
+	 *
+	 * @return string
+	 */
+	public function get_command_client_txn_id(): ?string;
+
+	/**
+	 * Gets the server_txn_id from the command related to this event, if any
+	 *
+	 * @return string
+	 */
+	public function get_command_server_txn_id(): ?string;
+}

--- a/lib/event/async-command-related-trait.php
+++ b/lib/event/async-command-related-trait.php
@@ -1,0 +1,59 @@
+<?php declare( strict_types=1 );
+/*
+ * Copyright (c) 2022 Automattic, Inc.
+ *
+ * This file is part of the Automattic Domain Services Client library.
+ *
+ * The Automattic Domain Services Client library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program;
+ * if not, see https://www.gnu.org/licenses.
+ */
+
+namespace Automattic\Domain_Services_Client\Event;
+
+trait Async_Command_Related_Trait {
+	use Data_Trait;
+
+	/**
+	 * Gets the status code for this event
+	 *
+	 * @return int
+	 */
+	public function get_command_status(): ?int {
+		return $this->get_data_by_key( Event_Interface::KEY_COMMAND_STATUS );
+	}
+
+	/**
+	 * Gets a description of the status code meaning
+	 *
+	 * @return string
+	 */
+	public function get_command_status_description(): ?string {
+		return $this->get_data_by_key( Event_Interface::KEY_COMMAND_STATUS_DESCRIPTION );
+	}
+
+	/**
+	 * Gets the client_txn_id from the command related to this event, if any
+	 *
+	 * @return string
+	 */
+	public function get_command_client_txn_id(): ?string {
+		return $this->get_data_by_key( Event_Interface::KEY_COMMAND_CLIENT_TNX_ID );
+	}
+
+	/**
+	 * Gets the server_txn_id from the command related to this event, if any
+	 *
+	 * @return string
+	 */
+	public function get_command_server_txn_id(): ?string {
+		return $this->get_data_by_key( Event_Interface::KEY_COMMAND_SERVER_TNX_ID );
+	}
+}

--- a/lib/event/async-command-related-trait.php
+++ b/lib/event/async-command-related-trait.php
@@ -48,7 +48,7 @@ trait Async_Command_Related_Trait {
 	 * @return string
 	 */
 	public function get_command_client_txn_id(): ?string {
-		return $this->get_data_by_key( Event_Interface::KEY_COMMAND_CLIENT_TNX_ID );
+		return $this->get_data_by_key( Event_Interface::KEY_COMMAND_CLIENT_TXN_ID );
 	}
 
 	/**
@@ -57,6 +57,6 @@ trait Async_Command_Related_Trait {
 	 * @return string
 	 */
 	public function get_command_server_txn_id(): ?string {
-		return $this->get_data_by_key( Event_Interface::KEY_COMMAND_SERVER_TNX_ID );
+		return $this->get_data_by_key( Event_Interface::KEY_COMMAND_SERVER_TXN_ID );
 	}
 }

--- a/lib/event/async-command-related-trait.php
+++ b/lib/event/async-command-related-trait.php
@@ -18,6 +18,9 @@
 
 namespace Automattic\Domain_Services_Client\Event;
 
+/**
+ * Used by all events resulting from running an asynchronous command
+ */
 trait Async_Command_Related_Trait {
 	use Data_Trait;
 

--- a/lib/event/data-trait.php
+++ b/lib/event/data-trait.php
@@ -29,7 +29,7 @@ trait Data_Trait {
 	 *
 	 * @var array
 	 */
-	private array $data;
+	protected array $data;
 
 	/**
 	 * Constructs an event object
@@ -44,14 +44,20 @@ trait Data_Trait {
 	 * Gets the value of the event data specified by the given key.
 	 *
 	 * @param string $key
-	 * @return array|mixed|null
+	 *
+	 * @return mixed
 	 */
 	final public function get_data_by_key( string $key ) {
 		$key_parts = explode( '.', $key );
 		$data = $this->data;
 		foreach ( $key_parts as $key_part ) {
-			$data = $data[ $key_part ] ?? null;
+			if ( ! isset( $data[ $key_part ] ) ) {
+				return null;
+			}
+
+			$data = $data[ $key_part ];
 		}
+
 		return $data;
 	}
 
@@ -61,7 +67,7 @@ trait Data_Trait {
 	 * @return int
 	 */
 	public function get_id(): int {
-		return $this->get_data_by_key( 'id' );
+		return $this->get_data_by_key( Event_Interface::KEY_ID );
 	}
 
 	/**
@@ -70,7 +76,7 @@ trait Data_Trait {
 	 * @return string
 	 */
 	public function get_event_class(): string {
-		return $this->get_data_by_key( 'event_class' );
+		return $this->get_data_by_key( Event_Interface::KEY_EVENT_CLASS );
 	}
 
 	/**
@@ -79,7 +85,7 @@ trait Data_Trait {
 	 * @return string
 	 */
 	public function get_event_subclass(): string {
-		return $this->get_data_by_key( 'event_subclass' );
+		return $this->get_data_by_key( Event_Interface::KEY_EVENT_SUBCLASS );
 	}
 
 	/**
@@ -88,7 +94,7 @@ trait Data_Trait {
 	 * @return string
 	 */
 	public function get_object_type(): string {
-		return $this->get_data_by_key( 'object_type' );
+		return $this->get_data_by_key( Event_Interface::KEY_OBJECT_TYPE );
 	}
 
 	/**
@@ -99,7 +105,7 @@ trait Data_Trait {
 	 * @return string
 	 */
 	public function get_object_id(): string {
-		return $this->get_data_by_key( 'object_id' );
+		return $this->get_data_by_key( Event_Interface::KEY_OBJECT_ID );
 	}
 
 	/**
@@ -108,7 +114,7 @@ trait Data_Trait {
 	 * @return \DateTimeInterface
 	 */
 	public function get_event_date(): \DateTimeInterface {
-		return Helper\Date_Time::createImmutable( $this->get_data_by_key( 'event_date' ) );
+		return Helper\Date_Time::createImmutable( $this->get_data_by_key( Event_Interface::KEY_EVENT_DATE ) );
 	}
 
 	/**
@@ -117,47 +123,11 @@ trait Data_Trait {
 	 * @return \DateTimeInterface|null
 	 */
 	public function get_acknowledged_date(): ?\DateTimeInterface {
-		$acknowledged_date = $this->get_data_by_key( 'acknowledged_date' );
+		$acknowledged_date = $this->get_data_by_key( Event_Interface::KEY_ACKNOWLEDGED_DATE );
 		if ( null === $acknowledged_date ) {
 			return null;
 		}
 
-		return Helper\Date_Time::createImmutable( $this->get_data_by_key( 'acknowledged_date' ) );
-	}
-
-	/**
-	 * Gets the status code for this event
-	 *
-	 * @return int
-	 */
-	public function get_event_status(): ?int {
-		return $this->get_data_by_key( 'event_data.status' );
-	}
-
-	/**
-	 * Gets a description of the status code meaning
-	 *
-	 * @return string
-	 */
-	public function get_event_status_description(): ?string {
-		return $this->get_data_by_key( 'event_data.status_description' );
-	}
-
-	/**
-	 * Gets the client_txn_id from the command related to this event, if any
-	 *
-	 * @return string
-	 */
-	public function get_event_client_txn_id(): ?string {
-		return $this->get_data_by_key( 'event_data.client_txn_id' );
-	}
-
-	/**
-	 * Gets the server_txn_id from the command related to this event, if any
-	 *
-	 * @return string
-	 */
-	public function get_event_server_txn_id(): ?string {
-		return $this->get_data_by_key( 'event_data.server_txn_id' );
+		return Helper\Date_Time::createImmutable( $acknowledged_date );
 	}
 }

--- a/lib/event/domain/delete/fail.php
+++ b/lib/event/domain/delete/fail.php
@@ -27,8 +27,8 @@ use Automattic\Domain_Services_Client\{Event};
  *
  * @see \Automattic\Domain_Services_Client\Command\Domain\Delete
  */
-class Fail implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Fail implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Error_Trait;
 	use Event\Object_Type_Domain_Trait;
 }

--- a/lib/event/domain/delete/success.php
+++ b/lib/event/domain/delete/success.php
@@ -27,7 +27,7 @@ use Automattic\Domain_Services_Client\{Event};
  *
  * @see \Automattic\Domain_Services_Client\Command\Domain\Delete
  */
-class Success implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Success implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
 }

--- a/lib/event/domain/register/fail.php
+++ b/lib/event/domain/register/fail.php
@@ -28,8 +28,8 @@ use Automattic\Domain_Services_Client\{Event};
  *
  * @see \Automattic\Domain_Services_Client\Command\Domain\Register
  */
-class Fail implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Fail implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Error_Trait;
 	use Event\Object_Type_Domain_Trait;
 }

--- a/lib/event/domain/register/success.php
+++ b/lib/event/domain/register/success.php
@@ -27,8 +27,8 @@ use Automattic\Domain_Services_Client\{Entity, Event, Exception, Helper};
  *
  * @see \Automattic\Domain_Services_Client\Command\Domain\Register
  */
-class Success implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Success implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
 
 	/**

--- a/lib/event/domain/renew/fail.php
+++ b/lib/event/domain/renew/fail.php
@@ -28,8 +28,8 @@ use Automattic\Domain_Services_Client\{Event};
  *
  * @see \Automattic\Domain_Services_Client\Command\Domain\Renew
  */
-class Fail implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Fail implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Error_Trait;
 	use Event\Object_Type_Domain_Trait;
 }

--- a/lib/event/domain/renew/success.php
+++ b/lib/event/domain/renew/success.php
@@ -18,7 +18,7 @@
 
 namespace Automattic\Domain_Services_Client\Event\Domain\Renew;
 
-use Automattic\Domain_Services_Client\{Entity, Event, Helper, Exception};
+use Automattic\Domain_Services_Client\{Entity, Event, Helper};
 
 /**
  * Domain renewed successfully event
@@ -27,15 +27,14 @@ use Automattic\Domain_Services_Client\{Entity, Event, Helper, Exception};
  *
  * @see \Automattic\Domain_Services_Client\Command\Domain\Renew
  */
-class Success implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Success implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
 
 	/**
 	 * Returns the domain status after the renewal operation
 	 *
 	 * @return Entity\Epp_Status_Codes
-	 * @throws Exception\Entity\Invalid_Value_Exception
 	 */
 	public function get_domain_status(): Entity\Epp_Status_Codes {
 		$epp_statuses_data = $this->get_data_by_key( 'event_data.domain_status' );
@@ -43,6 +42,7 @@ class Success implements Event\Event_Interface {
 		foreach ( $epp_statuses_data as $epp_status_data ) {
 			$epp_statuses[] = new Entity\Epp_Status_Code( $epp_status_data );
 		}
+
 		return new Entity\Epp_Status_Codes( ...$epp_statuses );
 	}
 
@@ -53,6 +53,7 @@ class Success implements Event\Event_Interface {
 	 */
 	public function get_expiration_date(): ?\DateTimeInterface {
 		$expiration_date = $this->get_data_by_key( 'event_data.expiration_date' );
+
 		return null === $expiration_date ? null : Helper\Date_Time::createImmutable( $expiration_date );
 	}
 
@@ -63,6 +64,7 @@ class Success implements Event\Event_Interface {
 	 */
 	public function get_renewable_until(): ?\DateTimeInterface {
 		$renewable_until = $this->get_data_by_key( 'event_data.renewable_until' );
+
 		return null === $renewable_until ? null : Helper\Date_Time::createImmutable( $renewable_until );
 	}
 }

--- a/lib/event/domain/restore/fail.php
+++ b/lib/event/domain/restore/fail.php
@@ -28,8 +28,8 @@ use Automattic\Domain_Services_Client\{Event};
  *
  * @see \Automattic\Domain_Services_Client\Command\Domain\Restore
  */
-class Fail implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Fail implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Error_Trait;
 	use Event\Object_Type_Domain_Trait;
 }

--- a/lib/event/domain/restore/success.php
+++ b/lib/event/domain/restore/success.php
@@ -18,7 +18,7 @@
 
 namespace Automattic\Domain_Services_Client\Event\Domain\Restore;
 
-use Automattic\Domain_Services_Client\{Entity, Event, Helper, Exception};
+use Automattic\Domain_Services_Client\{Entity, Event, Helper};
 
 /**
  * Success event for a `Domain\Restore` command.
@@ -27,15 +27,14 @@ use Automattic\Domain_Services_Client\{Entity, Event, Helper, Exception};
  *
  * @see \Automattic\Domain_Services_Client\Command\Domain\Restore
  */
-class Success implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Success implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
 
 	/**
 	 * Gets the status of the domain immediately after the restore operation.
 	 *
 	 * @return Entity\Epp_Status_Codes
-	 * @throws Exception\Entity\Invalid_Value_Exception
 	 */
 	public function get_domain_status(): Entity\Epp_Status_Codes {
 		$epp_statuses_data = $this->get_data_by_key( 'event_data.domain_status' );

--- a/lib/event/domain/set/contacts/fail.php
+++ b/lib/event/domain/set/contacts/fail.php
@@ -25,8 +25,8 @@ use Automattic\Domain_Services_Client\{Command, Event};
  *
  * @see Command\Domain\Set\Contacts
  */
-class Fail implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Fail implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
 	use Event\Error_Trait;
 }

--- a/lib/event/domain/set/contacts/success.php
+++ b/lib/event/domain/set/contacts/success.php
@@ -25,8 +25,8 @@ use Automattic\Domain_Services_Client\{Command, Entity, Event, Exception};
  *
  * @see Command\Domain\Set\Contacts
  */
-class Success implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Success implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
 
 	/**

--- a/lib/event/domain/set/nameservers/fail.php
+++ b/lib/event/domain/set/nameservers/fail.php
@@ -27,8 +27,8 @@ use Automattic\Domain_Services_Client\{Event};
  *
  * @see \Automattic\Domain_Services_Client\Command\Domain\Set\Nameservers
  */
-class Fail implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Fail implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Error_Trait;
 	use Event\Object_Type_Domain_Trait;
 }

--- a/lib/event/domain/set/nameservers/success.php
+++ b/lib/event/domain/set/nameservers/success.php
@@ -28,8 +28,8 @@ use Automattic\Domain_Services_Client\{Entity, Event, Exception};
  *
  * @see \Automattic\Domain_Services_Client\Command\Domain\Set\Nameservers
  */
-class Success implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Success implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
 
 	/**

--- a/lib/event/domain/set/privacy/fail.php
+++ b/lib/event/domain/set/privacy/fail.php
@@ -27,8 +27,8 @@ use Automattic\Domain_Services_Client\{Event};
  *
  * @see \Automattic\Domain_Services_Client\Command\Domain\Set\Privacy
  */
-class Fail implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Fail implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Error_Trait;
 	use Event\Object_Type_Domain_Trait;
 }

--- a/lib/event/domain/set/privacy/success.php
+++ b/lib/event/domain/set/privacy/success.php
@@ -28,8 +28,8 @@ use Automattic\Domain_Services_Client\{Entity, Event, Exception};
  *
  * @see \Automattic\Domain_Services_Client\Command\Domain\Set\Privacy
  */
-class Success implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Success implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
 
 	/**

--- a/lib/event/domain/set/transferlock/fail.php
+++ b/lib/event/domain/set/transferlock/fail.php
@@ -25,8 +25,8 @@ use Automattic\Domain_Services_Client\{Command, Event};
  *
  * @see Command\Domain\Set\Transferlock
  */
-class Fail implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Fail implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Error_Trait;
 	use Event\Object_Type_Domain_Trait;
 }

--- a/lib/event/domain/set/transferlock/success.php
+++ b/lib/event/domain/set/transferlock/success.php
@@ -25,8 +25,8 @@ use Automattic\Domain_Services_Client\{Event, Command};
  *
  * @see Command\Domain\Set\Transferlock
  */
-class Success implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Success implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
 
 	/**

--- a/lib/event/domain/transfer/in/fail.php
+++ b/lib/event/domain/transfer/in/fail.php
@@ -27,8 +27,8 @@ use Automattic\Domain_Services_Client\{Event};
  *   successfully started
  * - There might be more information about the cause of the failure in the event data
  */
-class Fail implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Fail implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
 	use Event\Transfer_Trait;
 }

--- a/lib/event/domain/transfer/in/pending.php
+++ b/lib/event/domain/transfer/in/pending.php
@@ -25,8 +25,8 @@ use Automattic\Domain_Services_Client\{Event};
  *
  * This event is generated when a domain transfer from another registrar to the reseller's account is started.
  */
-class Pending implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Pending implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
 	use Event\Transfer_Trait;
 }

--- a/lib/event/domain/transfer/in/success.php
+++ b/lib/event/domain/transfer/in/success.php
@@ -25,8 +25,8 @@ use Automattic\Domain_Services_Client\{Event};
  *
  * This event is generated when a domain transfer from another registrar to the reseller's account is successful.
  */
-class Success implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Success implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
 	use Event\Transfer_Trait;
 }

--- a/lib/event/domain/transfer/out/fail.php
+++ b/lib/event/domain/transfer/out/fail.php
@@ -26,8 +26,8 @@ use Automattic\Domain_Services_Client\{Event};
  * - This event is generated when a domain transfer to another registrar fails after it was successfully started
  * - There might be more information about the cause of the failure in the event data
  */
-class Fail implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Fail implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
 	use Event\Transfer_Trait;
 }

--- a/lib/event/domain/transfer/out/pending.php
+++ b/lib/event/domain/transfer/out/pending.php
@@ -25,8 +25,8 @@ use Automattic\Domain_Services_Client\{Event};
  *
  * This event is generated when a domain transfer to another registrar is started.
  */
-class Pending implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Pending implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
 	use Event\Transfer_Trait;
 }

--- a/lib/event/domain/transfer/out/success.php
+++ b/lib/event/domain/transfer/out/success.php
@@ -25,8 +25,8 @@ use Automattic\Domain_Services_Client\{Event};
  *
  * This event is generated when a domain transfer to another registrar is successful.
  */
-class Success implements Event\Event_Interface {
-	use Event\Data_Trait;
+class Success implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
 	use Event\Transfer_Trait;
 }

--- a/lib/event/error-trait.php
+++ b/lib/event/error-trait.php
@@ -45,6 +45,6 @@ trait Error_Trait {
 	 * @return array[]
 	 */
 	final public function get_event_errors(): array {
-		return $this->get_data_by_key( 'event_data.errors' );
+		return $this->get_data_by_key( Event_Interface::KEY_EVENT_ERRORS );
 	}
 }

--- a/lib/event/event-interface.php
+++ b/lib/event/event-interface.php
@@ -22,4 +22,77 @@ namespace Automattic\Domain_Services_Client\Event;
  * An interface used by all event classes.
  */
 interface Event_Interface {
+
+	public const KEY_ID = 'id';
+	public const KEY_OBJECT_ID = 'object_id';
+	public const KEY_OBJECT_TYPE = 'object_type';
+	public const KEY_EVENT_DATE = 'event_date';
+	public const KEY_ACKNOWLEDGED_DATE = 'acknowledged_date';
+	public const KEY_EVENT_CLASS = 'event_class';
+	public const KEY_EVENT_SUBCLASS = 'event_subclass';
+	public const KEY_EVENT_ERRORS = 'event_data.errors';
+	public const KEY_COMMAND_STATUS = 'event_data.status';
+	public const KEY_COMMAND_STATUS_DESCRIPTION = 'event_data.status_description';
+	public const KEY_COMMAND_CLIENT_TNX_ID = 'event_data.client_tnx_id';
+	public const KEY_COMMAND_SERVER_TNX_ID = 'event_data.server_tnx_id';
+
+	/**
+	 * Gets the value of the event data specified by the given key.
+	 *
+	 * @param string $key
+	 *
+	 * @return mixed
+	 */
+	public function get_data_by_key( string $key );
+
+	/**
+	 * Gets the event ID
+	 *
+	 * @return int
+	 */
+	public function get_id(): int;
+
+	/**
+	 * Gets the event class
+	 *
+	 * @return string
+	 */
+	public function get_event_class(): string;
+
+	/**
+	 * Gets the event subclass
+	 *
+	 * @return string
+	 */
+	public function get_event_subclass(): string;
+
+	/**
+	 * Gets the type of object that this event references (ex. 'domain' or 'contact')
+	 *
+	 * @return string
+	 */
+	public function get_object_type(): string;
+
+	/**
+	 * Gets the ID of the object that this event references.
+	 * - The contact ID for a contact object type
+	 * - The domain name for a domain object type
+	 *
+	 * @return string
+	 */
+	public function get_object_id(): string;
+
+	/**
+	 * Gets the date this event was generated.
+	 *
+	 * @return \DateTimeInterface
+	 */
+	public function get_event_date(): \DateTimeInterface;
+
+	/**
+	 * Gets the date this event was acknowledged.
+	 *
+	 * @return \DateTimeInterface|null
+	 */
+	public function get_acknowledged_date(): ?\DateTimeInterface;
 }

--- a/lib/event/event-interface.php
+++ b/lib/event/event-interface.php
@@ -33,8 +33,8 @@ interface Event_Interface {
 	public const KEY_EVENT_ERRORS = 'event_data.errors';
 	public const KEY_COMMAND_STATUS = 'event_data.status';
 	public const KEY_COMMAND_STATUS_DESCRIPTION = 'event_data.status_description';
-	public const KEY_COMMAND_CLIENT_TNX_ID = 'event_data.client_tnx_id';
-	public const KEY_COMMAND_SERVER_TNX_ID = 'event_data.server_tnx_id';
+	public const KEY_COMMAND_CLIENT_TXN_ID = 'event_data.client_txn_id';
+	public const KEY_COMMAND_SERVER_TXN_ID = 'event_data.server_txn_id';
 
 	/**
 	 * Gets the value of the event data specified by the given key.

--- a/test/lib/domain-services-client-test-case.php
+++ b/test/lib/domain-services-client-test-case.php
@@ -20,7 +20,7 @@ namespace Automattic\Domain_Services_Client\Test\Lib;
 
 use Automattic\Domain_Services_Client\{Event, Helper, Response};
 
-class Domain_Services_Client_Test_Case extends \PHPUnit\Framework\TestCase {
+abstract class Domain_Services_Client_Test_Case extends \PHPUnit\Framework\TestCase {
 	protected Response\Factory $response_factory;
 
 	public function setUp(): void {
@@ -58,10 +58,13 @@ class Domain_Services_Client_Test_Case extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals( $expected_event_data['object_id'], $event->get_object_id() );
 		$this->assertEquals( $expected_event_data['event_date'], Helper\Date_Time::format( $event->get_event_date() ) );
 		$this->assertEquals( $expected_event_data['acknowledged_date'], null === $event->get_acknowledged_date() ? null : Helper\Date_Time::format( $event->get_acknowledged_date() ) );
-		$this->assertEquals( $expected_event_data['event_data']['status'] ?? null, $event->get_event_status() );
-		$this->assertEquals( $expected_event_data['event_data']['status_description'] ?? null, $event->get_event_status_description() );
-		$this->assertEquals( $expected_event_data['event_data']['client_txn_id'] ?? null, $event->get_event_client_txn_id() );
-		$this->assertEquals( $expected_event_data['event_data']['server_txn_id'] ?? null, $event->get_event_server_txn_id() );
+
+		if ( $event instanceof Event\Async_Command_Related_Interface ) {
+			$this->assertEquals( $expected_event_data['event_data']['status_description'] ?? null, $event->get_command_status_description() );
+			$this->assertEquals( $expected_event_data['event_data']['client_txn_id'] ?? null, $event->get_command_client_txn_id() );
+			$this->assertEquals( $expected_event_data['event_data']['server_txn_id'] ?? null, $event->get_command_server_txn_id() );
+			$this->assertEquals( $expected_event_data['event_data']['status'] ?? null, $event->get_command_status() );
+		}
 
 		if ( 'domain' === $expected_event_data['object_type'] ) {
 			$this->assertSame( $expected_event_data['object_id'], $event->get_domain()->get_name() );


### PR DESCRIPTION
This PR:
* Introduces a new trait `Event\Async_Command_Related_Trait` and interface `Event\Async_Command_Related_Interface` to encapsulate the logic specific to events we queue as a response to an asynchronous command.
* Define the methods in `Event\Data_Trait` in `Event_Interface` to make it easier to reference these in code (thanks @fredrikekelund for the suggestion!).
* Define constants for event data keys in the `Event_Interface`