### PR TITLE
Update Suggestion entity to be in sync with server

### DIFF
--- a/lib/entity/domain-suggestion.php
+++ b/lib/entity/domain-suggestion.php
@@ -71,7 +71,7 @@ class Suggestion {
 	}
 
 	/**
-	 * Returns uf the domain suggestion is premium
+	 * Returns whether the domain suggestion is premium
 	 *
 	 * @return bool
 	 */

--- a/lib/entity/domain-suggestion.php
+++ b/lib/entity/domain-suggestion.php
@@ -34,7 +34,12 @@ class Suggestion {
 	/**
 	 * @var int fee the reseller must pay to register this domain
 	 */
-	private int $reseller_fee;
+	private int $reseller_register_fee;
+
+	/**
+	 * @var int fee the reseller must pay to renew this domain
+	 */
+	private int $reseller_renewal_fee;
 
 	/**
 	 * @var bool is the suggestion a premium domain?
@@ -46,9 +51,10 @@ class Suggestion {
 	 *
 	 * @param Domain_Name $domain_name
 	 */
-	public function __construct( Domain_Name $domain_name, int $reseller_fee = 0, bool $is_premium = false ) {
+	public function __construct( Domain_Name $domain_name, int $reseller_create_fee = 0, int $reseller_renewal_fee = 0, bool $is_premium = false ) {
 		$this->domain_name = $domain_name;
-		$this->reseller_fee = $reseller_fee;
+		$this->reseller_register_fee = $reseller_create_fee;
+		$this->reseller_renewal_fee = $reseller_renewal_fee;
 		$this->is_premium = $is_premium;
 	}
 
@@ -66,8 +72,17 @@ class Suggestion {
 	 *
 	 * @return int
 	 */
-	public function get_reseller_fee(): int {
-		return $this->reseller_fee;
+	public function get_reseller_register_fee(): int {
+		return $this->reseller_register_fee;
+	}
+
+	/**
+	 * Returns the reseller fee to renew this domain
+	 *
+	 * @return int
+	 */
+	public function get_reseller_renewal_fee(): int {
+		return $this->reseller_renewal_fee;
 	}
 
 	/**
@@ -88,7 +103,8 @@ class Suggestion {
 	public function to_array(): array {
 		return [
 			'name' => $this->domain_name->get_name(),
-			'reseller_fee' => $this->get_reseller_fee(),
+			'reseller_register_fee' => $this->get_reseller_register_fee(),
+			'reseller_renewal_fee' => $this->get_reseller_renewal_fee(),
 			'is_premium' => $this->is_premium(),
 		];
 	}

--- a/lib/entity/domain-suggestion.php
+++ b/lib/entity/domain-suggestion.php
@@ -32,12 +32,24 @@ class Suggestion {
 	private Domain_Name $domain_name;
 
 	/**
+	 * @var int fee the reseller must pay to register this domain
+	 */
+	private int $reseller_fee;
+
+	/**
+	 * @var bool is the suggestion a premium domain?
+	 */
+	private bool $is_premium;
+
+	/**
 	 * Constructs a `Suggestion` entity
 	 *
 	 * @param Domain_Name $domain_name
 	 */
-	public function __construct( Domain_Name $domain_name ) {
+	public function __construct( Domain_Name $domain_name, int $reseller_fee = 0, bool $is_premium = false ) {
 		$this->domain_name = $domain_name;
+		$this->reseller_fee = $reseller_fee;
+		$this->is_premium = $is_premium;
 	}
 
 	/**
@@ -50,7 +62,25 @@ class Suggestion {
 	}
 
 	/**
-	 * Returns an associative array containing the domain name suggestion
+	 * Returns the reseller fee to register this domain
+	 *
+	 * @return int
+	 */
+	public function get_reseller_fee(): int {
+		return $this->reseller_fee;
+	}
+
+	/**
+	 * Returns uf the domain suggestion is premium
+	 *
+	 * @return bool
+	 */
+	public function is_premium(): bool {
+		return $this->is_premium;
+	}
+
+	/**
+	 * Returns an associative array containing the domain name suggestion and its related properties
 	 *
 	 * @internal
 	 * @return array
@@ -58,6 +88,8 @@ class Suggestion {
 	public function to_array(): array {
 		return [
 			'name' => $this->domain_name->get_name(),
+			'reseller_fee' => $this->get_reseller_fee(),
+			'is_premium' => $this->is_premium(),
 		];
 	}
 }

--- a/lib/response/domain/suggestions.php
+++ b/lib/response/domain/suggestions.php
@@ -39,7 +39,14 @@ class Suggestions implements Response\Response_Interface {
 		$suggestions = new Entity\Suggestions();
 		foreach ( $suggestions_data as $suggestion_data ) {
 			$domain_name = new Entity\Domain_Name( $suggestion_data['name'] );
-			$suggestions->add_suggestion( new Entity\Suggestion( $domain_name, $suggestion_data['reseller_fee'], $suggestion_data['is_premium'] ) );
+			$suggestions->add_suggestion(
+				new Entity\Suggestion(
+					$domain_name,
+					$suggestion_data['reseller_register_fee'],
+					$suggestion_data['reseller_renewal_fee'],
+					$suggestion_data['is_premium']
+				)
+			);
 		}
 
 		return $suggestions;

--- a/lib/response/domain/suggestions.php
+++ b/lib/response/domain/suggestions.php
@@ -39,7 +39,7 @@ class Suggestions implements Response\Response_Interface {
 		$suggestions = new Entity\Suggestions();
 		foreach ( $suggestions_data as $suggestion_data ) {
 			$domain_name = new Entity\Domain_Name( $suggestion_data['name'] );
-			$suggestions->add_suggestion( new Entity\Suggestion( $domain_name ) );
+			$suggestions->add_suggestion( new Entity\Suggestion( $domain_name, $suggestion_data['reseller_fee'], $suggestion_data['is_premium'] ) );
 		}
 
 		return $suggestions;

--- a/test/entity/domain-suggestions-test.php
+++ b/test/entity/domain-suggestions-test.php
@@ -22,9 +22,9 @@ use Automattic\Domain_Services_Client\{Entity, Test};
 
 class Domain_Suggestions_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_entity_instance_success(): void {
-		$domain_suggestion_data = array_map( static fn( $i ) => [ 'name' => "example$i.blog" ], range( 1, 10 ) );
+		$domain_suggestion_data = array_map( static fn( $i ) => [ 'name' => "example$i.blog", 'reseller_fee' => 100, 'is_premium' => false ], range( 1, 10 ) );
 		$domain_name_list = array_map( static fn( $n ) => new Entity\Domain_Name( $n['name'] ), $domain_suggestion_data );
-		$suggestion_list = array_map( static fn( $d ) => new Entity\Suggestion( $d ), $domain_name_list );
+		$suggestion_list = array_map( static fn( $dn, $dsd ) => new Entity\Suggestion( $dn, $dsd['reseller_fee'], $dsd['is_premium'] ), $domain_name_list, $domain_suggestion_data );
 		$suggestions = new Entity\Suggestions( ... $suggestion_list );
 
 		$this->assertArraysEqual( $domain_suggestion_data, $suggestions->to_array()['suggestions'] );

--- a/test/entity/domain-suggestions-test.php
+++ b/test/entity/domain-suggestions-test.php
@@ -22,9 +22,26 @@ use Automattic\Domain_Services_Client\{Entity, Test};
 
 class Domain_Suggestions_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_entity_instance_success(): void {
-		$domain_suggestion_data = array_map( static fn( $i ) => [ 'name' => "example$i.blog", 'reseller_fee' => 100, 'is_premium' => false ], range( 1, 10 ) );
+		$domain_suggestion_data = array_map(
+			static fn( $i ) => [
+				'name' => "example$i.blog",
+				'reseller_register_fee' => 100 * $i,
+				'reseller_renewal_fee' => 100 * $i,
+				'is_premium' => false
+			],
+			range( 1, 10 )
+		);
 		$domain_name_list = array_map( static fn( $n ) => new Entity\Domain_Name( $n['name'] ), $domain_suggestion_data );
-		$suggestion_list = array_map( static fn( $dn, $dsd ) => new Entity\Suggestion( $dn, $dsd['reseller_fee'], $dsd['is_premium'] ), $domain_name_list, $domain_suggestion_data );
+		$suggestion_list = array_map(
+			static fn( $domain_name, $domain_suggestion_datum ) => new Entity\Suggestion(
+				$domain_name,
+				$domain_suggestion_datum['reseller_register_fee'],
+				$domain_suggestion_datum['reseller_renewal_fee'],
+				$domain_suggestion_datum['is_premium']
+			),
+			$domain_name_list,
+			$domain_suggestion_data
+		);
 		$suggestions = new Entity\Suggestions( ... $suggestion_list );
 
 		$this->assertArraysEqual( $domain_suggestion_data, $suggestions->to_array()['suggestions'] );

--- a/test/response/domain-suggestions-test.php
+++ b/test/response/domain-suggestions-test.php
@@ -31,7 +31,14 @@ class Domain_Suggestions_Test extends Test\Lib\Domain_Services_Client_Test_Case 
 			'timestamp' => 1669075520,
 			'runtime' => 0.0021,
 			'data' => [
-				'suggestions' => array_map( static fn( $i ) => [ 'name' => "example$i.blog", 'reseller_fee' => 0, 'is_premium' => false ], range( 1, 10 ) ),
+				'suggestions' => array_map(
+					static fn( $i ) => [
+						'name' => "example$i.blog",
+						'reseller_fee' => $i * 100,
+						'is_premium' => false
+					],
+					range( 1, 10 )
+				),
 			],
 		];
 

--- a/test/response/domain-suggestions-test.php
+++ b/test/response/domain-suggestions-test.php
@@ -31,7 +31,7 @@ class Domain_Suggestions_Test extends Test\Lib\Domain_Services_Client_Test_Case 
 			'timestamp' => 1669075520,
 			'runtime' => 0.0021,
 			'data' => [
-				'suggestions' => array_map( static fn( $i ) => [ 'name' => "example$i.blog" ], range( 1, 10 ) ),
+				'suggestions' => array_map( static fn( $i ) => [ 'name' => "example$i.blog", 'reseller_fee' => 0, 'is_premium' => false ], range( 1, 10 ) ),
 			],
 		];
 

--- a/test/response/domain-suggestions-test.php
+++ b/test/response/domain-suggestions-test.php
@@ -34,7 +34,8 @@ class Domain_Suggestions_Test extends Test\Lib\Domain_Services_Client_Test_Case 
 				'suggestions' => array_map(
 					static fn( $i ) => [
 						'name' => "example$i.blog",
-						'reseller_fee' => $i * 100,
+						'reseller_register_fee' => $i * 100,
+						'reseller_renewal_fee' => $i * 100,
 						'is_premium' => false
 					],
 					range( 1, 10 )


### PR DESCRIPTION
This PR updates the `Suggestion` entity to be in sync with the server entity. The `reseller_fee` and `is_premium` properties are added.

### Testing

- Run unit tests with

```
composer update; ./vendor/bin/phpunit -c ./test/phpunit.xml
```