### PR TITLE
Add getter for domain associated with contact handle in `Contact\Verification\Notify` event

### DIFF
--- a/lib/event/contact/verification/notify.php
+++ b/lib/event/contact/verification/notify.php
@@ -37,4 +37,13 @@ class Notify implements Event\Event_Interface {
 	public function is_verified(): bool {
 		return $this->get_data_by_key( 'event_data.verified' ) ?? false;
 	}
+
+	/**
+	 * Returns the domain associated with the event's contact handle
+	 *
+	 * @return string
+	 */
+	public function get_associated_domain(): string {
+		return $this->get_data_by_key( 'event_data.associated_domain' ) ?? '';
+	}
 }

--- a/test/event/contact-verification-notify-test.php
+++ b/test/event/contact-verification-notify-test.php
@@ -43,6 +43,7 @@ class Contact_Verification_Notify_Test extends Test\Lib\Domain_Services_Client_T
 					'acknowledged_date' => null,
 					'event_data' => [
 						'verified' => true,
+						'associated_domain' => 'example.com',
 					],
 				],
 			],
@@ -59,6 +60,7 @@ class Contact_Verification_Notify_Test extends Test\Lib\Domain_Services_Client_T
 		$this->assertInstanceOf( Event\Contact\Verification\Notify::class, $event );
 		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['verified'], $event->is_verified() );
+		$this->assertSame( $response_data['data']['event']['event_data']['associated_domain'], $event->get_associated_domain() );
 		$this->assertSame( $response_data['data']['event']['object_id'], (string) $event->get_contact_id() );
 	}
 }


### PR DESCRIPTION
This PR adds the domain that a contact handle is associated with to the `Contact\Verification\Notify` reseller event. That way, resellers can know which domain might have been unsuspended when this contact was verified.

### Testing

- Ensure all unit tests are passing

```
composer update; ./vendor/bin/phpunit -c ./test/phpunit.xml
```