### PR TITLE
Update Domain\Set\Privacy command to be synchronous

### DIFF
--- a/lib/command/domain/set/privacy.php
+++ b/lib/command/domain/set/privacy.php
@@ -23,10 +23,6 @@ use Automattic\Domain_Services_Client\{Command, Entity};
 /**
  * Sets the privacy option that determines what contact information is shown in WHOIS.
  *
- * - Runs asynchronously on the server
- * - Reseller will receive a `Domain\Set\Privacy\Success` or `Domain\Set\Privacy\Fail` event depending on the result of the
- * command
- *
  * Example:
  * ```
  * $domain_name = new Entity\Domain_Name( 'example-domain.com' );

--- a/lib/command/domain/set/privacy.php
+++ b/lib/command/domain/set/privacy.php
@@ -38,7 +38,6 @@ use Automattic\Domain_Services_Client\{Command, Entity};
  * }
  * ```
  *
- * @see \Automattic\Domain_Services_Client\Command\Domain\Set\Privacy
  * @see \Automattic\Domain_Services_Client\Response\Domain\Set\Privacy
  */
 class Privacy implements Command\Command_Interface, Command\Command_Serialize_Interface {

--- a/lib/command/domain/set/privacy.php
+++ b/lib/command/domain/set/privacy.php
@@ -34,12 +34,11 @@ use Automattic\Domain_Services_Client\{Command, Entity};
  * $command = new Command\Domain\Set\Privacy( $domain, $privacy_setting );
  * $response = $api->post( $command );
  * if ( $response->is_success() ) {
- *   // the request to update the privacy setting was queued successfully
+ *   // the request to update the privacy has been successfully processed
  * }
  * ```
  *
- * @see \Automattic\Domain_Services_Client\Event\Domain\Set\Privacy\Fail
- * @see \Automattic\Domain_Services_Client\Event\Domain\Set\Privacy\Success
+ * @see \Automattic\Domain_Services_Client\Command\Domain\Set\Privacy
  * @see \Automattic\Domain_Services_Client\Response\Domain\Set\Privacy
  */
 class Privacy implements Command\Command_Interface, Command\Command_Serialize_Interface {

--- a/lib/response/domain/set/privacy.php
+++ b/lib/response/domain/set/privacy.php
@@ -23,12 +23,9 @@ use Automattic\Domain_Services_Client\{Response};
 /**
  * Response of a `Domain\Set\Privacy` command
  *
- * Since the command runs asynchronously on the server, success response indicates that request has been queued, not
- * completed.
+ * Success response indicates that request has been successfully processed.
  *
  * @see \Automattic\Domain_Services_Client\Command\Domain\Set\Privacy
- * @see \Automattic\Domain_Services_Client\Event\Domain\Set\Privacy\Success
- * @see \Automattic\Domain_Services_Client\Event\Domain\Set\Privacy\Fail
  */
 class Privacy implements Response\Response_Interface {
 	use Response\Data_Trait;


### PR DESCRIPTION
We are converting all Domain edit command to be synchronous (as in the first implementation).

This PR deals with `Domain\Set\Privacy` command.

### Testing:
```
./vendor/bin/phpunit -c ./test/phpunit.xml
```