### PR TITLE
Update Domain\Set\Transferlock command to be synchronous

### DIFF
--- a/lib/command/domain/set/transferlock.php
+++ b/lib/command/domain/set/transferlock.php
@@ -25,6 +25,16 @@ use Automattic\Domain_Services_Client\{Command, Entity};
  *
  * This commands requests either enabling or disabling the transfer lock on a specific domain.
  *
+ * Example:
+ * ```
+ * $domain_name = new Entity\Domain_Name( 'example-domain.com' );
+ * $command = new Command\Domain\Set\Transferlock( $domain, true );
+ * $response = $api->post( $command );
+ * if ( $response->is_success() ) {
+ *   // the request to update transferlock setting has been successfully processed
+ * }
+ * ```
+ *
  * @see \Automattic\Domain_Services_Client\Response\Domain\Set\Transferlock
  */
 class Transferlock implements Command\Command_Interface, Command\Command_Serialize_Interface {

--- a/lib/response/domain/set/privacy.php
+++ b/lib/response/domain/set/privacy.php
@@ -30,3 +30,4 @@ use Automattic\Domain_Services_Client\{Response};
 class Privacy implements Response\Response_Interface {
 	use Response\Data_Trait;
 }
+

--- a/lib/response/domain/set/privacy.php
+++ b/lib/response/domain/set/privacy.php
@@ -23,7 +23,7 @@ use Automattic\Domain_Services_Client\{Response};
 /**
  * Response of a `Domain\Set\Privacy` command
  *
- * Success response indicates that request has been successfully processed.
+ * - A Success response indicates that request has been successfully processed
  *
  * @see \Automattic\Domain_Services_Client\Command\Domain\Set\Privacy
  */

--- a/lib/response/domain/set/transferlock.php
+++ b/lib/response/domain/set/transferlock.php
@@ -23,6 +23,8 @@ use Automattic\Domain_Services_Client\Response;
 /**
  * Response of a `Domain\Transferlock\Set` command.
  *
+ * - A Success response indicates that request has been successfully processed
+ *
  * @see \Automattic\Domain_Services_Client\Command\Domain\Set\Transferlock
  */
 class Transferlock implements Response\Response_Interface {


### PR DESCRIPTION
We are converting all Domain edit command to be synchronous (as in the first implementation).

This PR deals with `Domain\Set\Transferlock` command.

### Testing:
```
./vendor/bin/phpunit -c ./test/phpunit.xml
```