### PR TITLE
Update Domain\Set\Nameservers command to be synchronous

### DIFF
--- a/lib/command/domain/set/nameservers.php
+++ b/lib/command/domain/set/nameservers.php
@@ -23,10 +23,6 @@ use Automattic\Domain_Services_Client\{Command, Entity};
 /**
  * Sets name servers for the specified domain
  *
- * - Runs asynchronously on the server
- * - Reseller will receive a `Domain\Set\Nameservers\Success` or `Domain\Set\Nameservers\Fail` event depending on the
- *   result of the operation
- *
  * Example usage:
  *
  * ```
@@ -41,14 +37,11 @@ use Automattic\Domain_Services_Client\{Command, Entity};
  * $response = $api->post( $command );
  *
  * if ( $response->is_success() ) {
- *     // command was issued successfully, the client should wait for a `Domain\Set\Nameservers\Success` or
- *     `Domain\Set\Nameservers\Fail event`
+ *     // The request has been successfully processed
  * }
  * ```
  *
  * @see \Automattic\Domain_Services_Client\Response\Domain\Set\Nameservers
- * @see \Automattic\Domain_Services_Client\Event\Domain\Set\Nameservers\Success
- * @see \Automattic\Domain_Services_Client\Event\Domain\Set\Nameservers\Fail
  */
 class Nameservers implements Command\Command_Interface, Command\Command_Serialize_Interface {
 	use Command\Command_Serialize_Trait;

--- a/lib/response/domain/set/nameservers.php
+++ b/lib/response/domain/set/nameservers.php
@@ -23,14 +23,9 @@ use Automattic\Domain_Services_Client\Response;
 /**
  * Response of a `Domain\Set\Nameservers` command
  *
- * - The name server update operation runs asynchronously at the server
- * - A success response indicates that the operation was queued, not completed
- *     - The `Domain\Set\Nameservers\Success` and `Domain\Set\Nameservers\Fail` events will indicate whether the
- *       operation was successful or not
+ * - A success response indicates that the operation has been processed successfully
  *
  * @see \Automattic\Domain_Services_Client\Command\Domain\Set\Nameservers
- * @see \Automattic\Domain_Services_Client\Event\Domain\Set\Nameservers\Success
- * @see \Automattic\Domain_Services_Client\Event\Domain\Set\Nameservers\Fail
  */
 class Nameservers implements Response\Response_Interface {
 	use Response\Data_Trait;


### PR DESCRIPTION
We are converting all Domain edit command to be synchronous (as in the first implementation).

This PR deals with `Domain\Set\Nameservers` command.

### Testing:
```
./vendor/bin/phpunit -c ./test/phpunit.xml
```