### PR TITLE
Add `tlds` and `exact_match` options to `Domain\Suggestions` command

### DIFF
--- a/lib/command/command-interface.php
+++ b/lib/command/command-interface.php
@@ -37,6 +37,7 @@ interface Command_Interface {
 	public const KEY_DOMAIN = 'domain';
 	public const KEY_DOMAINS = 'domains';
 	public const KEY_EVENT_ID = 'event_id';
+	public const KEY_EXACT_MATCH = 'exact_match';
 	public const KEY_FEE_AMOUNT = 'fee_amount';
 	public const KEY_LIMIT = 'limit';
 	public const KEY_NAMESERVERS = 'nameservers';
@@ -46,6 +47,7 @@ interface Command_Interface {
 	public const KEY_QUERY = 'query';
 	public const KEY_RECORD_SETS = 'record_sets';
 	public const KEY_RECORDS = 'dns_records';
+	public const KEY_TLDS = 'tlds';
 	public const KEY_TRANSFERLOCK = 'transferlock';
 
 	/**

--- a/lib/command/domain/suggestions.php
+++ b/lib/command/domain/suggestions.php
@@ -40,14 +40,28 @@ class Suggestions implements Command\Command_Interface, Command\Command_Serializ
 	private int $quantity;
 
 	/**
+	 * @var array|null list of TLDs that the retrieved suggestions should be limited to (optional, defaults to all available TLDs for the reseller)
+	 */
+	private ?array $tlds;
+
+	/**
+	 * @var bool whether the retrieved suggestions should be an exact match of the query string (optional, default to false)
+	 */
+	private bool $exact_match;
+
+	/**
 	 * Constructs a `Domain\Suggestions` command
 	 *
 	 * @param string $query
-	 * @param int    $quantity
+	 * @param int $quantity
+	 * @param array|null $tlds
+	 * @param bool $exact_match
 	 */
-	public function __construct( string $query, int $quantity ) {
+	public function __construct( string $query, int $quantity, ?array $tlds = null, bool $exact_match = false ) {
 		$this->query = $query;
 		$this->quantity = $quantity;
+		$this->tlds = $tlds;
+		$this->exact_match = $exact_match;
 	}
 
 	/**
@@ -69,6 +83,24 @@ class Suggestions implements Command\Command_Interface, Command\Command_Serializ
 	}
 
 	/**
+	 * Returns the list of TLDs that the retrieved suggestions should be limited to
+	 *
+	 * @return array|null
+	 */
+	public function get_tlds(): ?array {
+		return $this->tlds ?? null;
+	}
+
+	/**
+	 * Returns whether the retrieved suggestions should be an exact match of the query string
+	 *
+	 * @return bool
+	 */
+	public function is_exact_match(): bool {
+		return $this->exact_match;
+	}
+
+	/**
 	 * Converts the command to an associative array
 	 *
 	 * @internal
@@ -79,6 +111,8 @@ class Suggestions implements Command\Command_Interface, Command\Command_Serializ
 		return [
 			Command\Command_Interface::KEY_QUERY => $this->query,
 			Command\Command_Interface::KEY_QUANTITY => $this->quantity,
+			Command\Command_Interface::KEY_TLDS => $this->tlds,
+			Command\Command_Interface::KEY_EXACT_MATCH => $this->exact_match,
 		];
 	}
 }

--- a/test/command/domain-suggestions-test.php
+++ b/test/command/domain-suggestions-test.php
@@ -28,13 +28,17 @@ class Domain_Suggestions_Test extends Test\Lib\Domain_Services_Client_Test_Case 
 			Command\Command_Interface::PARAMS => [
 				Command\Command_Interface::KEY_QUERY => 'some query string',
 				Command\Command_Interface::KEY_QUANTITY => 10,
+				Command\Command_Interface::KEY_TLDS => [ 'com', 'net', 'org' ],
+				COmmand\Command_Interface::KEY_EXACT_MATCH => true,
 			],
 			Command\Command_Interface::CLIENT_TXN_ID => 'client-transaction-info-for-domain-suggestions-test-1',
 		];
 
 		$command = new Command\Domain\Suggestions(
 			$mock_command_data[ Command\Command_Interface::PARAMS ][ Command\Command_Interface::KEY_QUERY ],
-			$mock_command_data[ Command\Command_Interface::PARAMS ][ Command\Command_Interface::KEY_QUANTITY ]
+			$mock_command_data[ Command\Command_Interface::PARAMS ][ Command\Command_Interface::KEY_QUANTITY ],
+			$mock_command_data[ Command\Command_Interface::PARAMS ][ Command\Command_Interface::KEY_TLDS ],
+			$mock_command_data[ Command\Command_Interface::PARAMS ][ Command\Command_Interface::KEY_EXACT_MATCH ]
 		);
 		$command->set_client_txn_id( $mock_command_data[ Command\Command_Interface::CLIENT_TXN_ID ] );
 


### PR DESCRIPTION
This PR adds the `tlds` and `exact_match` options to the `Domain\Suggestions` command. These options give more control to which kinds of suggestions the reseller wants to receive.

### Testing

- Code inspection
- Ensure all unit tests are passing
```
composer update; ./vendor/bin/phpunit -c ./test/phpunit.xml
```