### PR TITLE
Update `Domain\Set\Contact` command to be synchronous

### DIFF
--- a/lib/command/domain/set/contacts.php
+++ b/lib/command/domain/set/contacts.php
@@ -27,8 +27,6 @@ use Automattic\Domain_Services_Client\{Command, Entity, Exception};
  * - Contact types not included in the request would not be updated, but won't be deleted.
  * - For each contact type, either a contact ID or the full contact information can be provided.
  * - If contact information is provided, a new contact will be created and the contact ID will be returned.
- * - This command runs asynchronously on the server.
- * - Getting a success response means that the operation was queued successfully.
  * - A domain has four contact types: owner, admin, tech and billing
  *
  * ## Example:
@@ -44,7 +42,7 @@ use Automattic\Domain_Services_Client\{Command, Entity, Exception};
  *
  * $response = $api->post( $command );
  * if ( $response->is_success() ) {
- *     // The update request was queued successfully
+ *     // The update request was successfully processed
  * }
  * ```
  *

--- a/lib/response/domain/set/contacts.php
+++ b/lib/response/domain/set/contacts.php
@@ -18,19 +18,14 @@
 
 namespace Automattic\Domain_Services_Client\Response\Domain\Set;
 
-use Automattic\Domain_Services_Client\{Event, Response, Command};
+use Automattic\Domain_Services_Client\{Response, Command};
 
 /**
  * Response of a `Domain\Set\Contacts` command
  *
- * - The contacts set operation runs asynchronously at the server
- * - A success response indicates that the operation was queued, not completed
- * - The `Domain\Set\Contacts\Success` and `Domain\Set\Contacts\Fail` events will indicate whether the operation was
- * successful or not
+ * - A success response indicates that the operation was successfully processed.
  *
  * @see Command\Domain\Set\Contacts
- * @see Event\Domain\Set\Contacts\Success
- * @see Event\Domain\Set\Contacts\Fail
  */
 class Contacts implements Response\Response_Interface {
 	use Response\Data_Trait;


### PR DESCRIPTION
We are converting all `Domain\Set\*` commands to be synchronous. This PR handles the `Domain\Set\Contact` command.

Testing:
```
./vendor/bin/phpunit -c ./test/phpunit.xml
```