### PR TITLE
Add the `transfer_locked_until_date` property to the relevant events

### DIFF
--- a/lib/event/domain/register/success.php
+++ b/lib/event/domain/register/success.php
@@ -116,4 +116,15 @@ class Success implements Event\Event_Interface, Event\Async_Command_Related_Inte
 
 		return null === $contact_data ? null : Entity\Domain_Contacts::from_array( $contact_data );
 	}
+
+	/**
+	 * Gets the date until when the domain is transfer locked
+	 *
+	 * @return \DateTimeInterface|null
+	 */
+	public function get_transfer_locked_until_date(): ?\DateTimeInterface {
+		$transfer_locked_until_date = $this->get_data_by_key( 'event_data.transfer_locked_until_date' );
+
+		return null === $transfer_locked_until_date ? null : Helper\Date_Time::createImmutable( $transfer_locked_until_date );
+	}
 }

--- a/lib/event/domain/register/success.php
+++ b/lib/event/domain/register/success.php
@@ -30,6 +30,7 @@ use Automattic\Domain_Services_Client\{Entity, Event, Exception, Helper};
 class Success implements Event\Event_Interface, Event\Async_Command_Related_Interface {
 	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
+	use Event\Transfer_Locked_Trait;
 
 	/**
 	 * Gets the date the domain will exit the Add Grace Period (AGP); null if no AGP is offered
@@ -115,16 +116,5 @@ class Success implements Event\Event_Interface, Event\Async_Command_Related_Inte
 		$contact_data = $this->get_data_by_key( 'event_data.contacts' ) ?? [];
 
 		return null === $contact_data ? null : Entity\Domain_Contacts::from_array( $contact_data );
-	}
-
-	/**
-	 * Gets the date until when the domain is transfer locked
-	 *
-	 * @return \DateTimeInterface|null
-	 */
-	public function get_transfer_locked_until_date(): ?\DateTimeInterface {
-		$transfer_locked_until_date = $this->get_data_by_key( 'event_data.transfer_locked_until_date' );
-
-		return null === $transfer_locked_until_date ? null : Helper\Date_Time::createImmutable( $transfer_locked_until_date );
 	}
 }

--- a/lib/event/domain/set/contacts/success.php
+++ b/lib/event/domain/set/contacts/success.php
@@ -18,7 +18,7 @@
 
 namespace Automattic\Domain_Services_Client\Event\Domain\Set\Contacts;
 
-use Automattic\Domain_Services_Client\{Command, Entity, Event, Helper, Exception};
+use Automattic\Domain_Services_Client\{Command, Entity, Event, Exception};
 
 /**
  * Event representing a `Domain\Set\Contacts` command success
@@ -28,6 +28,7 @@ use Automattic\Domain_Services_Client\{Command, Entity, Event, Helper, Exception
 class Success implements Event\Event_Interface, Event\Async_Command_Related_Interface {
 	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
+	use Event\Transfer_Locked_Trait;
 
 	/**
 	 * Returns the domain contacts of the updated domain
@@ -39,16 +40,5 @@ class Success implements Event\Event_Interface, Event\Async_Command_Related_Inte
 		$contact_data = $this->get_data_by_key( 'event_data.contacts' ) ?? [];
 
 		return Entity\Domain_Contacts::from_array( $contact_data );
-	}
-
-	/**
-	 * Gets the date until when the domain is transfer locked
-	 *
-	 * @return \DateTimeInterface|null
-	 */
-	public function get_transfer_locked_until_date(): ?\DateTimeInterface {
-		$transfer_locked_until_date = $this->get_data_by_key( 'event_data.transfer_locked_until_date' );
-
-		return null === $transfer_locked_until_date ? null : Helper\Date_Time::createImmutable( $transfer_locked_until_date );
 	}
 }

--- a/lib/event/domain/set/contacts/success.php
+++ b/lib/event/domain/set/contacts/success.php
@@ -18,7 +18,7 @@
 
 namespace Automattic\Domain_Services_Client\Event\Domain\Set\Contacts;
 
-use Automattic\Domain_Services_Client\{Command, Entity, Event, Exception};
+use Automattic\Domain_Services_Client\{Command, Entity, Event, Helper, Exception};
 
 /**
  * Event representing a `Domain\Set\Contacts` command success
@@ -39,5 +39,16 @@ class Success implements Event\Event_Interface, Event\Async_Command_Related_Inte
 		$contact_data = $this->get_data_by_key( 'event_data.contacts' ) ?? [];
 
 		return Entity\Domain_Contacts::from_array( $contact_data );
+	}
+
+	/**
+	 * Gets the date until when the domain is transfer locked
+	 *
+	 * @return \DateTimeInterface|null
+	 */
+	public function get_transfer_locked_until_date(): ?\DateTimeInterface {
+		$transfer_locked_until_date = $this->get_data_by_key( 'event_data.transfer_locked_until_date' );
+
+		return null === $transfer_locked_until_date ? null : Helper\Date_Time::createImmutable( $transfer_locked_until_date );
 	}
 }

--- a/lib/event/domain/transfer/in/success.php
+++ b/lib/event/domain/transfer/in/success.php
@@ -18,7 +18,7 @@
 
 namespace Automattic\Domain_Services_Client\Event\Domain\Transfer\In;
 
-use Automattic\Domain_Services_Client\{Event};
+use Automattic\Domain_Services_Client\{Event, Helper};
 
 /**
  * Inbound domain transfer success event
@@ -29,4 +29,15 @@ class Success implements Event\Event_Interface, Event\Async_Command_Related_Inte
 	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
 	use Event\Transfer_Trait;
+
+	/**
+	 * Gets the date until when the domain is transfer locked
+	 *
+	 * @return \DateTimeInterface|null
+	 */
+	public function get_transfer_locked_until_date(): ?\DateTimeInterface {
+		$transfer_locked_until_date = $this->get_data_by_key( 'event_data.transfer_locked_until_date' );
+
+		return null === $transfer_locked_until_date ? null : Helper\Date_Time::createImmutable( $transfer_locked_until_date );
+	}
 }

--- a/lib/event/transfer-locked-trait.php
+++ b/lib/event/transfer-locked-trait.php
@@ -16,18 +16,22 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services_Client\Event\Domain\Transfer\In;
+namespace Automattic\Domain_Services_Client\Event;
 
-use Automattic\Domain_Services_Client\{Event};
+use Automattic\Domain_Services_Client\{Helper};
 
 /**
- * Inbound domain transfer success event
- *
- * This event is generated when a domain transfer from another registrar to the reseller's account is successful.
+ * Trait that adds the `get_transfer_locked_until_date` method to an event
  */
-class Success implements Event\Event_Interface, Event\Async_Command_Related_Interface {
-	use Event\Async_Command_Related_Trait;
-	use Event\Object_Type_Domain_Trait;
-	use Event\Transfer_Trait;
-	use Event\Transfer_Locked_Trait;
+trait Transfer_Locked_Trait {
+	/**
+	 * Gets the date until when the domain is transfer locked
+	 *
+	 * @return \DateTimeInterface|null
+	 */
+	public function get_transfer_locked_until_date(): ?\DateTimeInterface {
+		$transfer_locked_until_date = $this->get_data_by_key( 'transfer_locked_until_date' );
+
+		return null === $transfer_locked_until_date ? null : Helper\Date_Time::createImmutable( $transfer_locked_until_date );
+	}
 }


### PR DESCRIPTION
This PR adds the `transfer_locked_until_date` property to the relevant events. These events are:

- `Domain\Register\Success` - newly registered domains are usually under a 60 day transfer lock
- `Domain\Transfer\In\Success` - newly transferred in domains are usually under a 60 day transfer lock
- `Domain\Set\Contacts\Success`
    - When the owner contact of a domain is updated (more specifically its first name, last name, email or organization fields) **and** the user does not opt out of the transfer lock, the domain is also put in a 60 day transfer lock

### Testing

- Code inspection
- Ensure all unit tests are passing:

```
./vendor/bin/phpunit -c ./test/phpunit.xml
```