### PR TITLE
Remove @internal from Response, Request and Event factory

### DIFF
--- a/lib/event/factory.php
+++ b/lib/event/factory.php
@@ -22,8 +22,6 @@ use Automattic\Domain_Services_Client\{Exception};
 
 /**
  * Factory class used to build an event from the provided data.
- *
- * @internal
  */
 class Factory {
 	/**

--- a/lib/request/factory.php
+++ b/lib/request/factory.php
@@ -24,8 +24,6 @@ use Psr\Http\Message\StreamFactoryInterface;
 
 /**
  * Factory for creating PSR-7 requests.
- *
- * @internal
  */
 class Factory {
 

--- a/lib/response/factory.php
+++ b/lib/response/factory.php
@@ -22,8 +22,6 @@ use Automattic\Domain_Services_Client\{Command, Event, Exception};
 
 /**
  * Factory for creating response objects.
- *
- * @internal
  */
 class Factory {
 	/**


### PR DESCRIPTION
`Response\Factory`, `Request\Factory` and `Event\Factory` classes shouldn't be marked as internal.

This quick pr addresses the issue.