### PR TITLE
Add `associated_domain` property to the `Contact\Verification\Request` event

### DIFF
--- a/lib/event/contact/verification/request.php
+++ b/lib/event/contact/verification/request.php
@@ -37,4 +37,13 @@ class Request implements Event\Event_Interface {
 	public function get_email(): ?string {
 		return $this->get_data_by_key( 'event_data.email' );
 	}
+
+	/**
+	 * Returns the domain associated with the event's contact handle
+	 *
+	 * @return string
+	 */
+	public function get_associated_domain(): string {
+		return $this->get_data_by_key( 'event_data.associated_domain' ) ?? '';
+	}
 }

--- a/test/event/contact-verification-request-test.php
+++ b/test/event/contact-verification-request-test.php
@@ -44,6 +44,7 @@ class Contact_Verification_Request_Test extends Test\Lib\Domain_Services_Client_
 					'event_data' => [
 						'email' => 'registrant@example.com',
 						'verification_code' => 'qwerty12345',
+						'associated_domain' => 'example.com',
 					],
 				],
 			],
@@ -60,6 +61,7 @@ class Contact_Verification_Request_Test extends Test\Lib\Domain_Services_Client_
 		$this->assertInstanceOf( Event\Contact\Verification\Request::class, $event );
 		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['email'], $event->get_email() );
+		$this->assertSame( $response_data['data']['event']['event_data']['associated_domain'], $event->get_associated_domain() );
 		$this->assertSame( $response_data['data']['event']['object_id'], (string) $event->get_contact_id() );
 	}
 }


### PR DESCRIPTION
This PR adds the `associated_domain` property to the `Contact\Verification\Request` event.

### Testing

Ensure all unit tests are passing:

```
./vendor/bin/phpunit -c ./test/phpunit.xml
```