### PR TITLE
Add  property to the suggestion entity

### DIFF
--- a/lib/api.php
+++ b/lib/api.php
@@ -87,10 +87,6 @@ class Api {
 		$request = $this->request_factory->createRequest( 'POST', $uri, $body, $headers );
 		$result = $this->http_client->sendRequest( $request );
 		$body = $result->getBody()->getContents();
-
-
-		var_dump( $body );
-
 		$result_data = json_decode( $body, true, 512, JSON_THROW_ON_ERROR );
 
 		return $this->response_factory->build_response( $command, $result_data );

--- a/lib/api.php
+++ b/lib/api.php
@@ -48,9 +48,9 @@ class Api {
 	/**
 	 * Constructs an Api object
 	 *
-	 * @param Configuration          $configuration
-	 * @param Request\Factory        $request_factory
-	 * @param Response\Factory       $response_factory
+	 * @param Configuration $configuration
+	 * @param Request\Factory $request_factory
+	 * @param Response\Factory $response_factory
 	 * @param Client\ClientInterface $http_client
 	 */
 	public function __construct( Configuration $configuration, Request\Factory $request_factory, Response\Factory $response_factory, Client\ClientInterface $http_client ) {
@@ -63,7 +63,7 @@ class Api {
 	/**
 	 * Executes a POST request using the provided command and client transaction ID
 	 *
-	 * @param Command\Command_Interface $command       The command to be executed.
+	 * @param Command\Command_Interface $command The command to be executed.
 	 * @param string                    $client_txn_id The client transaction ID to be included in the request.
 	 *
 	 * @return Response\Response_Interface The response object generated from the request's result.

--- a/lib/api.php
+++ b/lib/api.php
@@ -48,9 +48,9 @@ class Api {
 	/**
 	 * Constructs an Api object
 	 *
-	 * @param Configuration $configuration
-	 * @param Request\Factory $request_factory
-	 * @param Response\Factory $response_factory
+	 * @param Configuration          $configuration
+	 * @param Request\Factory        $request_factory
+	 * @param Response\Factory       $response_factory
 	 * @param Client\ClientInterface $http_client
 	 */
 	public function __construct( Configuration $configuration, Request\Factory $request_factory, Response\Factory $response_factory, Client\ClientInterface $http_client ) {
@@ -63,7 +63,7 @@ class Api {
 	/**
 	 * Executes a POST request using the provided command and client transaction ID
 	 *
-	 * @param Command\Command_Interface $command The command to be executed.
+	 * @param Command\Command_Interface $command       The command to be executed.
 	 * @param string                    $client_txn_id The client transaction ID to be included in the request.
 	 *
 	 * @return Response\Response_Interface The response object generated from the request's result.
@@ -87,10 +87,6 @@ class Api {
 		$request = $this->request_factory->createRequest( 'POST', $uri, $body, $headers );
 		$result = $this->http_client->sendRequest( $request );
 		$body = $result->getBody()->getContents();
-
-
-		var_dump( $body );
-
 		$result_data = json_decode( $body, true, 512, JSON_THROW_ON_ERROR );
 
 		return $this->response_factory->build_response( $command, $result_data );

--- a/lib/api.php
+++ b/lib/api.php
@@ -87,6 +87,10 @@ class Api {
 		$request = $this->request_factory->createRequest( 'POST', $uri, $body, $headers );
 		$result = $this->http_client->sendRequest( $request );
 		$body = $result->getBody()->getContents();
+
+
+		var_dump( $body );
+
 		$result_data = json_decode( $body, true, 512, JSON_THROW_ON_ERROR );
 
 		return $this->response_factory->build_response( $command, $result_data );

--- a/lib/entity/domain-suggestion.php
+++ b/lib/entity/domain-suggestion.php
@@ -42,6 +42,11 @@ class Suggestion {
 	private int $reseller_renewal_fee;
 
 	/**
+	 * @var bool is the suggestion available?
+	 */
+	private bool $is_available;
+
+	/**
 	 * @var bool is the suggestion a premium domain?
 	 */
 	private bool $is_premium;
@@ -51,11 +56,12 @@ class Suggestion {
 	 *
 	 * @param Domain_Name $domain_name
 	 */
-	public function __construct( Domain_Name $domain_name, int $reseller_create_fee = 0, int $reseller_renewal_fee = 0, bool $is_premium = false ) {
+	public function __construct( Domain_Name $domain_name, int $reseller_create_fee = 0, int $reseller_renewal_fee = 0, bool $is_premium = false, bool $is_available = true ) {
 		$this->domain_name = $domain_name;
 		$this->reseller_register_fee = $reseller_create_fee;
 		$this->reseller_renewal_fee = $reseller_renewal_fee;
 		$this->is_premium = $is_premium;
+		$this->is_available = $is_available;
 	}
 
 	/**
@@ -86,6 +92,15 @@ class Suggestion {
 	}
 
 	/**
+	 * Returns whether the domain suggestion is available
+	 *
+	 * @return bool
+	 */
+	public function is_available(): bool {
+		return $this->is_available;
+	}
+
+	/**
 	 * Returns whether the domain suggestion is premium
 	 *
 	 * @return bool
@@ -97,8 +112,8 @@ class Suggestion {
 	/**
 	 * Returns an associative array containing the domain name suggestion and its related properties
 	 *
-	 * @internal
 	 * @return array
+	 * @internal
 	 */
 	public function to_array(): array {
 		return [
@@ -106,6 +121,7 @@ class Suggestion {
 			'reseller_register_fee' => $this->get_reseller_register_fee(),
 			'reseller_renewal_fee' => $this->get_reseller_renewal_fee(),
 			'is_premium' => $this->is_premium(),
+			'is_available' => $this->is_available(),
 		];
 	}
 }

--- a/lib/response/domain/suggestions.php
+++ b/lib/response/domain/suggestions.php
@@ -44,7 +44,8 @@ class Suggestions implements Response\Response_Interface {
 					$domain_name,
 					$suggestion_data['reseller_register_fee'],
 					$suggestion_data['reseller_renewal_fee'],
-					$suggestion_data['is_premium']
+					$suggestion_data['is_premium'],
+					$suggestion_data['is_available']
 				)
 			);
 		}

--- a/test/command/domain-set-contacts-test.php
+++ b/test/command/domain-set-contacts-test.php
@@ -54,7 +54,7 @@ class Domain_Set_Contacts_Test extends Test\Lib\Domain_Services_Client_Test_Case
 
 		$domain = new Entity\Domain_Name( $mock_command_data[ Command\Command_Interface::PARAMS ][ Command\Command_Interface::KEY_DOMAIN ] );
 		$contacts = Entity\Domain_Contacts::from_array( $mock_command_data[ Command\Command_Interface::PARAMS ][ Command\Command_Interface::KEY_CONTACTS ] );
-		$command = new Command\Domain\Set\Contacts( $domain, $contacts, false );
+		$command = new Command\Domain\Set\Contacts( $domain, $contacts, true );
 		$command->set_client_txn_id( $mock_command_data[ Command\Command_Interface::CLIENT_TXN_ID ] );
 
 		$this->assertInstanceOf( Command\Domain\Set\Contacts::class, $command );

--- a/test/entity/domain-suggestions-test.php
+++ b/test/entity/domain-suggestions-test.php
@@ -27,7 +27,8 @@ class Domain_Suggestions_Test extends Test\Lib\Domain_Services_Client_Test_Case 
 				'name' => "example$i.blog",
 				'reseller_register_fee' => 100 * $i,
 				'reseller_renewal_fee' => 100 * $i,
-				'is_premium' => false
+				'is_premium' => false,
+				'is_available' => true,
 			],
 			range( 1, 10 )
 		);

--- a/test/response/domain-suggestions-test.php
+++ b/test/response/domain-suggestions-test.php
@@ -36,7 +36,8 @@ class Domain_Suggestions_Test extends Test\Lib\Domain_Services_Client_Test_Case 
 						'name' => "example$i.blog",
 						'reseller_register_fee' => $i * 100,
 						'reseller_renewal_fee' => $i * 100,
-						'is_premium' => false
+						'is_premium' => false,
+						'is_available' => true,
 					],
 					range( 1, 10 )
 				),


### PR DESCRIPTION
This PR Adds an `is_available` property to the `Suggestion` entity.

## testing

Apply changes from D106668-code

Run the suggestions command and make sure that you get the is_available property in the results.

Something like this:

```
$guzzle_http_client = new GuzzleHttp\Client();
$http_factory = new \GuzzleHttp\Psr7\HttpFactory();
$request_factory = new Automattic\Domain_Services_Client\Request\Factory(
	$http_factory,
	$http_factory
);

$api = new Api(
	$config,
	$request_factory,
	new Response\Factory(),
	$guzzle_http_client,
);

$command = new Command\Domain\Suggestions( 'aksjlhdflaksjdhf.blog', 5 );

// Create an optional client transaction ID
$client_transaction_id = 'client_tx_id_example_' . date( 'Y-m-d_H:i:s' );

try {
	// Make the call to the endpoint
	/** @var Response\Domain\Suggestions $response */
	$response = $api->post( $command, $client_transaction_id );
	
	// Extract some data from the resopnse
	echo "Status: " . $response->get_status() . "\n";
	echo "Status description: " . $response->get_status_description() . "\n";
	echo $response->get_server_txn_id() . "\n";

	var_dump( $response->get_suggestions()->to_array() );

//	echo "New contact ID: " . $response->get_contacts()->get_owner()->get_contact_id()->get_provider_contact_id() . "\n";
} catch ( \Automattic\Domain_Services\Exception\Domain_Services_Exception $e ) {
	echo 'Exception when calling command: ', $e->getMessage(), PHP_EOL;
	var_dump( $e->getCode() );
	var_dump( $e->getMessage() );
}
```

