### PR TITLE
Update `Domain\Check` response

### DIFF
--- a/lib/response/domain/check.php
+++ b/lib/response/domain/check.php
@@ -37,6 +37,8 @@ class Check implements Response\Response_Interface {
 	 *     'domain_name' => [
 	 *         'available' => bool,
 	 *         'fee_class' => 'standard',
+	 *         'fee_amount' => 12.34,
+	 *         'zone_is_active' => true,
 	 *     ],
 	 * ]
 	 * ```

--- a/test/command/domain-set-contacts-test.php
+++ b/test/command/domain-set-contacts-test.php
@@ -47,7 +47,7 @@ class Domain_Set_Contacts_Test extends Test\Lib\Domain_Services_Client_Test_Case
 						Command\Command_Interface::KEY_CONTACT_DISCLOSURE => Entity\Contact_Disclosure::NONE,
 					],
 				],
-				Command\Command_Interface::KEY_TRANSFERLOCK_OPT_OUT => true,
+				Command\Command_Interface::KEY_TRANSFERLOCK_OPT_OUT => false,
 			],
 			Command\Command_Interface::CLIENT_TXN_ID => 'client-transaction-info-for-dns-records-get-test-1',
 		];

--- a/test/command/domain-set-contacts-test.php
+++ b/test/command/domain-set-contacts-test.php
@@ -47,7 +47,7 @@ class Domain_Set_Contacts_Test extends Test\Lib\Domain_Services_Client_Test_Case
 						Command\Command_Interface::KEY_CONTACT_DISCLOSURE => Entity\Contact_Disclosure::NONE,
 					],
 				],
-				Command\Command_Interface::KEY_TRANSFERLOCK_OPT_OUT => false,
+				Command\Command_Interface::KEY_TRANSFERLOCK_OPT_OUT => true,
 			],
 			Command\Command_Interface::CLIENT_TXN_ID => 'client-transaction-info-for-dns-records-get-test-1',
 		];

--- a/test/response/domain-check-test.php
+++ b/test/response/domain-check-test.php
@@ -41,14 +41,20 @@ class Domain_Check_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 					'test-domain-name-1.com' => [
 						'available' => true,
 						'fee_class' => 'standard',
+						'fee_amount' => 12.34,
+						'zone_is_active' => true,
 					],
 					'test-domain-name-2.com' => [
 						'available' => true,
 						'fee_class' => 'standard',
+						'fee_amount' => 12.34,
+						'zone_is_active' => true,
 					],
 					'test-domain-name-3.com' => [
 						'available' => false,
 						'fee_class' => 'standard',
+						'fee_amount' => 12.34,
+						'zone_is_active' => true,
 					],
 				],
 			],


### PR DESCRIPTION
This PR adds the `fee_amount` and `zone_is_enabled` properties to the `Domain\Check` response and updates unit tests. The PR actually only updates the comment in the response description, as the actual properties don't have specific getters. 

### Testing

- Ensure unit tests are passing:
```
./vendor/bin/phpunit -c ./test/phpunit.xml
```