### PR TITLE
Rename `transfer_lock` references to `transferlock`

### DIFF
--- a/docs/classes/Automattic-Domain-Services-Client-Command-Domain-Set-Transferlock.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Command-Domain-Set-Transferlock.md
@@ -43,7 +43,7 @@ if ( $response->is_success() ) {
 ### __construct
 
 ```
-public __construct(\Automattic\Domain_Services_Client\Entity\Domain_Name  domain, bool  transfer_lock) : mixed
+public __construct(\Automattic\Domain_Services_Client\Entity\Domain_Name  domain, bool  transferlock) : mixed
 ```
 
 ##### Summary
@@ -55,7 +55,7 @@ Constructs a `Domain\Set\Transferlock` command
 | Name | Type | Default |
 |------|------|---------|
 | **$domain** | \Automattic\Domain_Services_Client\Entity\Domain_Name |  |
-| **$transfer_lock** | bool |  |
+| **$transferlock** | bool |  |
 
 ##### Returns:
 

--- a/docs/classes/Automattic-Domain-Services-Client-Response-Domain-Info.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Response-Domain-Info.md
@@ -35,7 +35,7 @@ attributes of the domain at the registry.
 * public [get_status()](#method_get_status)
 * public [get_status_description()](#method_get_status_description)
 * public [get_timestamp()](#method_get_timestamp)
-* public [get_transfer_lock()](#method_get_transfer_lock)
+* public [get_transferlock()](#method_get_transferlock)
 * public [get_transfer_mode()](#method_get_transfer_mode)
 * public [get_updated_date()](#method_get_updated_date)
 * public [is_success()](#method_is_success)
@@ -507,11 +507,11 @@ int
 
 ---
 
-<a id="method_get_transfer_lock"></a>
-### get_transfer_lock
+<a id="method_get_transferlock"></a>
+### get_transferlock
 
 ```
-public get_transfer_lock() : bool|null
+public get_transferlock() : bool|null
 ```
 
 ##### Summary

--- a/lib/command/domain/set/transferlock.php
+++ b/lib/command/domain/set/transferlock.php
@@ -53,17 +53,17 @@ class Transferlock implements Command\Command_Interface, Command\Command_Seriali
 	 *
 	 * @var bool
 	 */
-	private bool $transfer_lock;
+	private bool $transferlock;
 
 	/**
 	 * Constructs a `Domain\Set\Transferlock` command
 	 *
 	 * @param Entity\Domain_Name $domain
-	 * @param bool               $transfer_lock
+	 * @param bool               $transferlock
 	 */
-	public function __construct( Entity\Domain_Name $domain, bool $transfer_lock ) {
+	public function __construct( Entity\Domain_Name $domain, bool $transferlock ) {
 		$this->domain = $domain;
-		$this->transfer_lock = $transfer_lock;
+		$this->transferlock = $transferlock;
 	}
 
 	/**
@@ -80,8 +80,8 @@ class Transferlock implements Command\Command_Interface, Command\Command_Seriali
 	 *
 	 * @return bool
 	 */
-	private function get_transfer_lock(): bool {
-		return $this->transfer_lock;
+	private function get_transferlock(): bool {
+		return $this->transferlock;
 	}
 
 	/**
@@ -94,7 +94,7 @@ class Transferlock implements Command\Command_Interface, Command\Command_Seriali
 	public function to_array(): array {
 		return [
 			Command\Command_Interface::KEY_DOMAIN => $this->get_domain()->get_name(),
-			Command\Command_Interface::KEY_TRANSFERLOCK => $this->get_transfer_lock(),
+			Command\Command_Interface::KEY_TRANSFERLOCK => $this->get_transferlock(),
 		];
 	}
 }

--- a/lib/event/domain/register/success.php
+++ b/lib/event/domain/register/success.php
@@ -30,7 +30,7 @@ use Automattic\Domain_Services_Client\{Entity, Event, Exception, Helper};
 class Success implements Event\Event_Interface, Event\Async_Command_Related_Interface {
 	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
-	use Event\Transfer_Locked_Trait;
+	use Event\TransferLocked_Trait;
 
 	/**
 	 * Gets the date the domain will exit the Add Grace Period (AGP); null if no AGP is offered

--- a/lib/event/domain/transfer/in/success.php
+++ b/lib/event/domain/transfer/in/success.php
@@ -29,5 +29,5 @@ class Success implements Event\Event_Interface, Event\Async_Command_Related_Inte
 	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
 	use Event\Transfer_Trait;
-	use Event\Transfer_Locked_Trait;
+	use Event\TransferLocked_Trait;
 }

--- a/lib/event/transfer-locked-trait.php
+++ b/lib/event/transfer-locked-trait.php
@@ -21,17 +21,17 @@ namespace Automattic\Domain_Services_Client\Event;
 use Automattic\Domain_Services_Client\{Helper};
 
 /**
- * Trait that adds the `get_transfer_locked_until_date` method to an event
+ * Trait that adds the `get_transferlocked_until_date` method to an event
  */
-trait Transfer_Locked_Trait {
+trait TransferLocked_Trait {
 	/**
 	 * Gets the date until when the domain is transfer locked
 	 *
 	 * @return \DateTimeInterface|null
 	 */
-	public function get_transfer_locked_until_date(): ?\DateTimeInterface {
-		$transfer_locked_until_date = $this->get_data_by_key( 'transfer_locked_until_date' );
+	public function get_transferlocked_until_date(): ?\DateTimeInterface {
+		$transferlocked_until_date = $this->get_data_by_key( 'transferlocked_until_date' );
 
-		return null === $transfer_locked_until_date ? null : Helper\Date_Time::createImmutable( $transfer_locked_until_date );
+		return null === $transferlocked_until_date ? null : Helper\Date_Time::createImmutable( $transferlocked_until_date );
 	}
 }

--- a/lib/response/domain/info.php
+++ b/lib/response/domain/info.php
@@ -179,8 +179,8 @@ class Info implements Response\Response_Interface {
 	 *
 	 * @return bool|null
 	 */
-	public function get_transfer_lock(): ?bool {
-		return $this->get_data_by_key( 'data.transfer_lock' );
+	public function get_transferlock(): ?bool {
+		return $this->get_data_by_key( 'data.transferlock' );
 	}
 
 	/**

--- a/lib/response/domain/set/contacts.php
+++ b/lib/response/domain/set/contacts.php
@@ -46,8 +46,8 @@ class Contacts implements Response\Response_Interface {
 	 *
 	 * @return string|null
 	 */
-	public function get_transfer_locked_until_date(): ?string {
-		return $this->get_data_by_key( 'data.transfer_locked_until_date' );
+	public function get_transferlocked_until_date(): ?string {
+		return $this->get_data_by_key( 'data.transferlocked_until_date' );
 	}
 
 	/**

--- a/test/response/domain-info-test.php
+++ b/test/response/domain-info-test.php
@@ -74,7 +74,7 @@ class Domain_Info_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 				'registrar_transfer_date' => NULL,
 				'renewal_mode' => 'DEFAULT',
 				'rgp_status' => 'addPeriod',
-				'transfer_lock' => true,
+				'transferlock' => true,
 				'transfer_mode' => 'DEFAULT',
 				'updated_date' => '2022-06-24 06:54:32',
 			],
@@ -98,7 +98,7 @@ class Domain_Info_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 		$this->assertEquals( $mock_response_data['data']['privacy_setting'], $response_object->get_privacy_setting()->get_setting() );
 		$this->assertEquals( $mock_response_data['data']['registrar_transfer_date'], $response_object->get_registrar_transfer_date() );
 		$this->assertEquals( $mock_response_data['data']['rgp_status'], $response_object->get_rgp_status() );
-		$this->assertEquals( $mock_response_data['data']['transfer_lock'], $response_object->get_transfer_lock() );
+		$this->assertEquals( $mock_response_data['data']['transferlock'], $response_object->get_transferlock() );
 		$this->assertEquals( $mock_response_data['data']['transfer_mode'], $response_object->get_transfer_mode() );
 		$this->assertEquals( $mock_response_data['data']['updated_date'], Helper\Date_Time::format( $response_object->get_updated_date() ) );
 	}

--- a/test/response/domain-set-contacts-test.php
+++ b/test/response/domain-set-contacts-test.php
@@ -77,7 +77,7 @@ class Domain_Set_Contacts_Test extends Test\Lib\Domain_Services_Client_Test_Case
 						'contact_disclosure' => 'none',
 					],
 				],
-				'transfer_locked_until_date' => '2022-06-22 01:23:45',
+				'transferlocked_until_date' => '2022-06-22 01:23:45',
 				'unverified_contact_suspension_date' => '2022-05-07 01:23:45',
 			],
 		];
@@ -91,7 +91,7 @@ class Domain_Set_Contacts_Test extends Test\Lib\Domain_Services_Client_Test_Case
 		$this->assertIsValidResponse( $mock_response_data, $response_object );
 
 		$this->assertEquals( $mock_response_data['data']['contacts'], $response_object->get_contacts()->to_array() );
-		$this->assertEquals( $mock_response_data['data']['transfer_locked_until_date'], $response_object->get_transfer_locked_until_date() );
+		$this->assertEquals( $mock_response_data['data']['transferlocked_until_date'], $response_object->get_transferlocked_until_date() );
 		$this->assertEquals( $mock_response_data['data']['unverified_contact_suspension_date'], $response_object->get_unverified_contact_suspension_date() );
 	}
 }


### PR DESCRIPTION
We want to standardize the `transferlock` property name across all references, this PR fixes it - it changes all references from `transfer_lock` to `transferlock`. 