### PR TITLE
Fix Invalid_Event_Name exception

### DIFF
--- a/lib/event/factory.php
+++ b/lib/event/factory.php
@@ -37,12 +37,12 @@ class Factory {
 		$event_subclass = $event_data['event_subclass'] ?? null;
 
 		if ( null === $event_class || null === $event_subclass ) {
-			throw new Exception\Event\Invalid_Event_Name( 'Missing event class or subclass' );
+			throw new Exception\Event\Invalid_Event_Name();
 		}
 
 		$class_name = __NAMESPACE__ . '\\' . $event_class . '\\' . $event_subclass;
 		if ( ! class_exists( $class_name ) ) {
-			throw new Exception\Event\Invalid_Event_Name( 'Event class does not exist: ' . $class_name );
+			throw new Exception\Event\Invalid_Event_Name( $event_class, $event_subclass );
 		}
 
 		return new $class_name( $event_data );

--- a/lib/exception/event/invalid-event-name.php
+++ b/lib/exception/event/invalid-event-name.php
@@ -23,4 +23,13 @@ use Automattic\Domain_Services_Client\{Exception};
 /**
  * Exception thrown when an invalid event name is used.
  */
-class Invalid_Event_Name extends Exception\Domain_Services_Exception { }
+class Invalid_Event_Name extends Exception\Domain_Services_Exception {
+	/**
+	 * Constructs a `Invalid_Event_Name` object.
+	 *
+	 * @internal
+	 */
+	public function __construct( ?string $invalid_event_class = null, ?string $invalid_event_subclass = null ) {
+		parent::__construct( Response\Code::INVALID_EVENT_NAME, [ 'event_class' => $invalid_event_class, 'event_subclass' => $invalid_event_subclass ] );
+	}
+}

--- a/lib/response/code.php
+++ b/lib/response/code.php
@@ -33,6 +33,7 @@ class Code {
 	public const INVALID_COMMAND_FORMAT = 507;
 	public const MISSING_REQUIRED_ENTITY = 508;
 	public const MISSING_COMMAND_OPTION = 509;
+  public const INVALID_EVENT_NAME = 510;
 	public const SERVER_CLOSING_CONNECTION = 520;
 	public const TOO_MANY_SESSIONS_OPEN = 521;
 	public const AUTHENTICATION_FAILED = 530;
@@ -52,6 +53,7 @@ class Code {
 		self::INVALID_ATTRIBUTE_VALUE_SYNTAX => 'Invalid attribute value syntax',
 		self::INVALID_OPTION_VALUE => 'Invalid option value',
 		self::INVALID_COMMAND_FORMAT => 'Invalid command format',
+		self::INVALID_EVENT_NAME => 'Invalid event name',
 		self::MISSING_REQUIRED_ENTITY => 'Missing required entity',
 		self::MISSING_COMMAND_OPTION => 'Missing command option',
 		self::SERVER_CLOSING_CONNECTION => 'Server closing connection. Client should try opening new connection',


### PR DESCRIPTION
This PR fixes `Invalid_Event_Name` exception, used in `Event_Factory`.