### PR TITLE
Remove `Contact_Id` and `Contact_Disclosure` from `Domain_Contact` constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ $domain_name = new Entity\Domain_Name( 'a8ctest.com' );
 // Set up a new domain contact
 $domain_contacts = new Entity\Domain_Contacts(
 	new Entity\Domain_Contact(
-		null,
 		new Entity\Contact_Information(
 			'John',
 			'Doe',
@@ -79,8 +78,7 @@ $domain_contacts = new Entity\Domain_Contacts(
 			'john.doe@example.com',
 			'+1.7575551234',
 			''
-		),
-		new Entity\Contact_Disclosure( \Automattic\Domain_Services_Client\Entity\Contact_Disclosure::NONE )
+		)
 	)
 );
 

--- a/lib/entity/domain-contact.php
+++ b/lib/entity/domain-contact.php
@@ -50,18 +50,12 @@ class Domain_Contact {
 	/**
 	 * Constructs a `Domain_Contact` entity
 	 *
-	 * @param Contact_Id|null $contact_id
 	 * @param Contact_Information|null $contact_info
-	 * @param Contact_Disclosure|null $disclose_fields
 	 */
-	public function __construct( ?Contact_Id $contact_id = null, ?Contact_Information $contact_info = null, ?Contact_Disclosure $disclose_fields = null ) {
-		$this->contact_id = $contact_id;
+	public function __construct( ?Contact_Information $contact_info = null ) {
+		$this->contact_id = null;
 		$this->contact_information = $contact_info;
-
-		if ( null === $disclose_fields ) {
-			$disclose_fields = new Contact_Disclosure( Contact_Disclosure::NONE );
-		}
-		$this->contact_disclosure = $disclose_fields;
+		$this->contact_disclosure = new Contact_Disclosure( Contact_Disclosure::NONE );
 	}
 
 	/**
@@ -131,7 +125,7 @@ class Domain_Contact {
 	/**
 	 * @param Contact_Id|null $contact_id
 	 */
-	public function set_contact_id( Contact_Id $contact_id ): void {
+	private function set_contact_id( Contact_Id $contact_id ): void {
 		$this->contact_id = $contact_id;
 	}
 
@@ -159,7 +153,7 @@ class Domain_Contact {
 	/**
 	 * @param Contact_Disclosure $contact_disclosure
 	 */
-	public function set_contact_disclosure( Contact_Disclosure $contact_disclosure ): void {
+	private function set_contact_disclosure( Contact_Disclosure $contact_disclosure ): void {
 		$this->contact_disclosure = $contact_disclosure;
 	}
 }

--- a/test/api/api-test.php
+++ b/test/api/api-test.php
@@ -31,7 +31,6 @@ class ApiTest extends Test\Lib\Domain_Services_Client_Test_Case {
 		// Set up a new domain contact
 		$domain_contacts = new Entity\Domain_Contacts(
 			new Entity\Domain_Contact(
-				null,
 				new Entity\Contact_Information(
 					'Del',
 					'Putnam',
@@ -45,8 +44,7 @@ class ApiTest extends Test\Lib\Domain_Services_Client_Test_Case {
 					'del@putnams.net',
 					'+1.7577468269',
 					null
-				),
-				new Entity\Contact_Disclosure( \Automattic\Domain_Services_Client\Entity\Contact_Disclosure::NONE )
+				)
 			)
 		);
 

--- a/test/entity/domain-contact-test.php
+++ b/test/entity/domain-contact-test.php
@@ -38,7 +38,7 @@ class Domain_Contact_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 		];
 
 		$contact_information_entity = Entity\Contact_Information::from_array( $contact_information );
-		$entity = new Entity\Domain_Contact( null, $contact_information_entity );
+		$entity = new Entity\Domain_Contact( $contact_information_entity );
 
 		$domain_contact = [
 			'contact_id' => null,
@@ -48,25 +48,6 @@ class Domain_Contact_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 
 		$this->assertSame( $contact_information_entity, $entity->get_contact_information() );
 		$this->assertNull( $entity->get_contact_id() );
-
-		$array = $entity->to_array();
-
-		$this->assertArraysEqual( $domain_contact, $array );
-	}
-
-	public function test_entity_instance_contact_id_success(): void {
-		$contact_id = 'SP1:A-34322';
-		$contact_id_entity = new Entity\Contact_Id( $contact_id );
-		$entity = new Entity\Domain_Contact( $contact_id_entity, null );
-
-		$domain_contact = [
-			'contact_id' => $contact_id,
-			'contact_information' => null,
-			'contact_disclosure' => 'none',
-		];
-
-		$this->assertSame( $contact_id_entity, $entity->get_contact_id() );
-		$this->assertNull( $entity->get_contact_information() );
 
 		$array = $entity->to_array();
 

--- a/test/entity/domain-contacts-test.php
+++ b/test/entity/domain-contacts-test.php
@@ -54,7 +54,7 @@ class Domain_Contacts_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 			];
 
 			$contact_information_entity = Entity\Contact_Information::from_array( $contact_information );
-			$domain_contact = new Entity\Domain_Contact( null, $contact_information_entity );
+			$domain_contact = new Entity\Domain_Contact( $contact_information_entity );
 
 			$entity->set_by_key( $type, $domain_contact );
 


### PR DESCRIPTION
This PR
- Removes the `Contact_Id` and `Contact_Disclosure` from the `Domain_Contact` constructor and
- Makes `set_contact_id` and `set_contact_disclosure` methods private

This prevents resellers from reusing contact IDs for different domains. Doing so would possibly result in unexpected situations and bugs that we want to avoid for now.

### Test plan

Ensure all unit tests are passing:

```
./vendor/bin/phpunit -c ./test/phpunit.xml
```