### PR TITLE
Add `zone_is_active` property to the `Suggestion` entity and related code

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,4 +6,4 @@
 
 
 --------
-> This document was automatically generated from source code comments on 2023-05-11
+> This document was automatically generated from source code comments on 2023-05-12

--- a/docs/classes/Automattic-Domain-Services-Client-Entity-Suggestion.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Entity-Suggestion.md
@@ -19,6 +19,7 @@ Used in the `Domain\Suggestions` response.
 * public [get_reseller_renewal_fee()](#method_get_reseller_renewal_fee)
 * public [is_available()](#method_is_available)
 * public [is_premium()](#method_is_premium)
+* public [is_zone_active()](#method_is_zone_active)
 
 ---
 
@@ -36,7 +37,7 @@ Used in the `Domain\Suggestions` response.
 ### __construct
 
 ```
-public __construct(\Automattic\Domain_Services_Client\Entity\Domain_Name  domain_name, int  reseller_create_fee, int  reseller_renewal_fee, bool  is_premium = false, bool  is_available = true) : mixed
+public __construct(\Automattic\Domain_Services_Client\Entity\Domain_Name  domain_name, int  reseller_create_fee, int  reseller_renewal_fee, bool  is_premium = false, bool  is_available = true, mixed  zone_is_active = true) : mixed
 ```
 
 ##### Summary
@@ -52,6 +53,7 @@ Constructs a `Suggestion` entity
 | **$reseller_renewal_fee** | int | 0 |
 | **$is_premium** | bool | false |
 | **$is_available** | bool | true |
+| **$zone_is_active** | mixed | true |
 
 ##### Returns:
 
@@ -147,6 +149,25 @@ public is_premium() : bool
 ##### Summary
 
 Returns whether the domain suggestion is premium
+
+##### Returns:
+
+```
+bool
+```
+
+---
+
+<a id="method_is_zone_active"></a>
+### is_zone_active
+
+```
+public is_zone_active() : bool
+```
+
+##### Summary
+
+Returns whether the domain suggestion&#039;s zone (TLD) is active for the reseller
 
 ##### Returns:
 

--- a/lib/entity/domain-suggestion.php
+++ b/lib/entity/domain-suggestion.php
@@ -52,16 +52,22 @@ class Suggestion {
 	private bool $is_premium;
 
 	/**
+	 * @var bool is this suggestion's zone (TLD) active for the reseller?
+	 */
+	private bool $zone_is_active;
+
+	/**
 	 * Constructs a `Suggestion` entity
 	 *
 	 * @param Domain_Name $domain_name
 	 */
-	public function __construct( Domain_Name $domain_name, int $reseller_create_fee = 0, int $reseller_renewal_fee = 0, bool $is_premium = false, bool $is_available = true ) {
+	public function __construct( Domain_Name $domain_name, int $reseller_create_fee = 0, int $reseller_renewal_fee = 0, bool $is_premium = false, bool $is_available = true, $zone_is_active = true ) {
 		$this->domain_name = $domain_name;
 		$this->reseller_register_fee = $reseller_create_fee;
 		$this->reseller_renewal_fee = $reseller_renewal_fee;
 		$this->is_premium = $is_premium;
 		$this->is_available = $is_available;
+		$this->zone_is_active = $zone_is_active;
 	}
 
 	/**
@@ -110,6 +116,15 @@ class Suggestion {
 	}
 
 	/**
+	 * Returns whether the domain suggestion's zone (TLD) is active for the reseller
+	 *
+	 * @return bool
+	 */
+	public function is_zone_active(): bool {
+		return $this->zone_is_active;
+	}
+
+	/**
 	 * Returns an associative array containing the domain name suggestion and its related properties
 	 *
 	 * @return array
@@ -122,6 +137,7 @@ class Suggestion {
 			'reseller_renewal_fee' => $this->get_reseller_renewal_fee(),
 			'is_premium' => $this->is_premium(),
 			'is_available' => $this->is_available(),
+			'zone_is_active' => $this->is_zone_active(),
 		];
 	}
 }

--- a/lib/response/domain/suggestions.php
+++ b/lib/response/domain/suggestions.php
@@ -45,7 +45,8 @@ class Suggestions implements Response\Response_Interface {
 					$suggestion_data['reseller_register_fee'],
 					$suggestion_data['reseller_renewal_fee'],
 					$suggestion_data['is_premium'],
-					$suggestion_data['is_available']
+					$suggestion_data['is_available'],
+					$suggestion_data['zone_is_active']
 				)
 			);
 		}

--- a/test/entity/domain-suggestions-test.php
+++ b/test/entity/domain-suggestions-test.php
@@ -29,6 +29,7 @@ class Domain_Suggestions_Test extends Test\Lib\Domain_Services_Client_Test_Case 
 				'reseller_renewal_fee' => 100 * $i,
 				'is_premium' => false,
 				'is_available' => true,
+				'zone_is_active' => true,
 			],
 			range( 1, 10 )
 		);
@@ -38,7 +39,8 @@ class Domain_Suggestions_Test extends Test\Lib\Domain_Services_Client_Test_Case 
 				$domain_name,
 				$domain_suggestion_datum['reseller_register_fee'],
 				$domain_suggestion_datum['reseller_renewal_fee'],
-				$domain_suggestion_datum['is_premium']
+				$domain_suggestion_datum['is_premium'],
+				$domain_suggestion_datum['zone_is_active']
 			),
 			$domain_name_list,
 			$domain_suggestion_data

--- a/test/response/domain-suggestions-test.php
+++ b/test/response/domain-suggestions-test.php
@@ -38,6 +38,7 @@ class Domain_Suggestions_Test extends Test\Lib\Domain_Services_Client_Test_Case 
 						'reseller_renewal_fee' => $i * 100,
 						'is_premium' => false,
 						'is_available' => true,
+						'zone_is_active' => true,
 					],
 					range( 1, 10 )
 				),


### PR DESCRIPTION
This PR adds the `zone_is_active` property to the `Suggestion` entity and `Domain\Suggestions` command response.

### Testing instructions

- Ensure unit tests are passing
```
composer update; ./vendor/bin/phpunit -c ./test/phpunit.xml
```
- Run the `Domain\Suggestions` command and ensure the `zone_is_active` property is correctly filled
