### PR TITLE
Add new email/send/verification command

### DIFF
--- a/lib/command/command-interface.php
+++ b/lib/command/command-interface.php
@@ -36,6 +36,7 @@ interface Command_Interface {
 	public const KEY_CURRENT_EXPIRATION_YEAR = 'current_expiration_year';
 	public const KEY_DOMAIN = 'domain';
 	public const KEY_DOMAINS = 'domains';
+	public const KEY_EMAIL = 'email';
 	public const KEY_EVENT_ID = 'event_id';
 	public const KEY_EXACT_MATCH = 'exact_match';
 	public const KEY_FEE_AMOUNT = 'fee_amount';

--- a/lib/command/email/send/verification.php
+++ b/lib/command/email/send/verification.php
@@ -1,0 +1,75 @@
+<?php declare( strict_types=1 );
+/*
+ * Copyright (c) 2022 Automattic, Inc.
+ *
+ * This file is part of the Automattic Domain Services Client library.
+ *
+ * The Automattic Domain Services Client library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program;
+ * if not, see https://www.gnu.org/licenses.
+ */
+
+namespace Automattic\Domain_Services_Client\Command\Email\Send;
+
+use Automattic\Domain_Services_Client\{Command, Entity, Exception};
+
+/**
+ * Resend email for domain contact verification
+ *
+ * @see \Automattic\Domain_Services_Client\Response\Domain\Set\Contacts
+ * @see Entity\Contact_Id
+ * @see Entity\Contact_Information
+ * @see Entity\Domain_Contacts
+ * @see Entity\Domain_Contact
+ */
+class Verification implements Command\Command_Interface, Command\Command_Serialize_Interface {
+	use Command\Command_Serialize_Trait;
+	use Command\Command_Trait;
+
+	/**
+	 * The domain name that will be updated.
+	 *
+	 * @var Entity\Email_Address
+	 */
+	private Entity\Email_Address $email_address;
+
+	/**
+	 * Constructs a `Email\Send\Verification` command
+	 *
+	 * @param Entity\Email_Address     $domain
+	 *
+	 * @throws Exception\Entity\Invalid_Value_Exception
+	 */
+	public function __construct( Entity\Email_Address $email_address ) {
+		$this->email_address = $email_address;
+	}
+
+	/**
+	 * Gets the domain name that will be updated
+	 *
+	 * @return Entity\Email_Address
+	 */
+	private function get_email_address(): Entity\Email_Address {
+		return $this->email_address;
+	}
+
+	/**
+	 * Converts the command to an associative array
+	 *
+	 * @internal
+	 *
+	 * @return array
+	 */
+	public function to_array(): array {
+		return [
+			Command\Command_Interface::KEY_EMAIL => $this->get_email_address()->get_email_address(),
+		];
+	}
+}

--- a/lib/entity/email-address.php
+++ b/lib/entity/email-address.php
@@ -1,0 +1,60 @@
+<?php declare( strict_types=1 );
+/*
+ * Copyright (c) 2022 Automattic, Inc.
+ *
+ * This file is part of the Automattic Domain Services Client library.
+ *
+ * The Automattic Domain Services Client library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program;
+ * if not, see https://www.gnu.org/licenses.
+ */
+
+namespace Automattic\Domain_Services_Client\Entity;
+
+/**
+ * Represents an email address
+ */
+class Email_Address {
+	/**
+	 * The email address string
+	 *
+	 * @var string
+	 */
+	private string $email_address;
+
+	/**
+	 * Constructs an `Email_Address` entity
+	 *
+	 * @param string $email_address
+	 */
+	public function __construct( string $email_address ) {
+		$this->email_address = $email_address;
+	}
+
+	/**
+	 * Returns the email address
+	 *
+	 * @return string
+	 */
+	public function get_email_address(): string {
+		return $this->email_address;
+	}
+
+	/**
+	 * Returns the string representation of the `Email_Address` object
+	 *
+	 * @internal
+	 *
+	 * @return string
+	 */
+	public function __toString() {
+		return $this->get_email_address();
+	}
+}

--- a/lib/response/email/send/verification.php
+++ b/lib/response/email/send/verification.php
@@ -1,0 +1,30 @@
+<?php declare( strict_types=1 );
+/*
+ * Copyright (c) 2022 Automattic, Inc.
+ *
+ * This file is part of the Automattic Domain Services Client library.
+ *
+ * The Automattic Domain Services Client library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program;
+ * if not, see https://www.gnu.org/licenses.
+ */
+
+namespace Automattic\Domain_Services_Client\Response\Email\Send;
+
+use Automattic\Domain_Services_Client\{Response};
+
+/**
+ * Response of an `Email\Send\Verification` command.
+ *
+ * @see \Automattic\Domain_Services_Client\Command\Email\Send\Verification
+ */
+class Verification implements Response\Response_Interface {
+	use Response\Data_Trait;
+}

--- a/test/command/email-send-verification-test.php
+++ b/test/command/email-send-verification-test.php
@@ -1,0 +1,45 @@
+<?php declare( strict_types=1 );
+/*
+ * Copyright (c) 2022 Automattic, Inc.
+ *
+ * This file is part of the Automattic Domain Services Client library.
+ *
+ * The Automattic Domain Services Client library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program;
+ * if not, see https://www.gnu.org/licenses.
+ */
+
+namespace Automattic\Domain_Services_Client\Test\Command;
+
+use Automattic\Domain_Services_Client\{Command, Entity, Test};
+
+class Email_Send_Verification_Test extends Test\Lib\Domain_Services_Client_Test_Case {
+
+	public function test_command_instance_success(): void {
+		$email = 'test@example.com';
+
+		$mock_command_data = [
+			Command\Command_Interface::COMMAND => 'Email\Send\Verification',
+			Command\Command_Interface::PARAMS => [
+				Command\Command_Interface::KEY_EMAIL => $email,
+			],
+			Command\Command_Interface::CLIENT_TXN_ID => 'client-transaction-info-for-event-ack-test-1',
+		];
+
+		$command = new Command\Email\Send\Verification( new Entity\Email_Address( $email ) );
+		$command->set_client_txn_id( $mock_command_data[ Command\Command_Interface::CLIENT_TXN_ID ] );
+
+		$this->assertInstanceOf( Command\Email\Send\Verification::class, $command );
+
+		$actual_command_array = $command->jsonSerialize();
+
+		$this->assertArraysEqual( $mock_command_data, $actual_command_array );
+	}
+}

--- a/test/response/email-send-verification-test.php
+++ b/test/response/email-send-verification-test.php
@@ -1,0 +1,45 @@
+<?php declare( strict_types=1 );
+/*
+ * Copyright (c) 2022 Automattic, Inc.
+ *
+ * This file is part of the Automattic Domain Services Client library.
+ *
+ * The Automattic Domain Services Client library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program;
+ * if not, see https://www.gnu.org/licenses.
+ */
+
+namespace Automattic\Domain_Services_Client\Test\Response;
+
+use Automattic\Domain_Services_Client\{Command, Entity, Response, Test};
+
+class Email_Send_Verificaiton_Test extends Test\Lib\Domain_Services_Client_Test_Case {
+	public function test_response_factory_success(): void {
+		$email_address = new Entity\Email_Address( 'test@example.com' );
+		$command = new Command\Email\Send\Verification( $email_address );
+
+		$response_data = [
+			'status' => 200,
+			'status_description' => 'Command completed successfully',
+			'success' => true,
+			'client_txn_id' => 'test-client-transaction-id',
+			'server_txn_id' => 'a819578a-6101-43cb-b55f-d1986215804b.local-isolated-test-request',
+			'timestamp' => 1669075524,
+			'runtime' => 0.0021,
+		];
+
+		/** @var Response\Email\Send\Verification $response_object */
+		$response_object = $this->response_factory->build_response( $command, $response_data );
+
+		$this->assertInstanceOf( Response\Email\Send\Verification::class, $response_object );
+
+		$this->assertIsValidResponse( $response_data, $response_object );
+	}
+}


### PR DESCRIPTION
We need to explose a command that'll allow clients to resend the domain contact verification email for email address. This is the client library code to expose that command.