### PR TITLE
Add the `tld_in_maintenance` property to the `Domain\Check` docs and unit tests

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,4 +6,4 @@
 
 
 --------
-> This document was automatically generated from source code comments on 2023-05-25
+> This document was automatically generated from source code comments on 2023-05-26

--- a/docs/classes/Automattic-Domain-Services-Client-Response-Domain-Check.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Response-Domain-Check.md
@@ -124,6 +124,7 @@ Gets the availability and pricing information for a list of domain from the resp
         &#039;fee_class&#039; =&gt; &#039;standard&#039;,
         &#039;fee_amount&#039; =&gt; 12.34,
         &#039;zone_is_active&#039; =&gt; true,
+        &#039;tld_in_maintenance&#039; =&gt; false,
     ],
 ]
 ```

--- a/lib/response/domain/check.php
+++ b/lib/response/domain/check.php
@@ -39,6 +39,7 @@ class Check implements Response\Response_Interface {
 	 *         'fee_class' => 'standard',
 	 *         'fee_amount' => 12.34,
 	 *         'zone_is_active' => true,
+	 *         'tld_in_maintenance' => false,
 	 *     ],
 	 * ]
 	 * ```

--- a/test/response/domain-check-test.php
+++ b/test/response/domain-check-test.php
@@ -25,7 +25,8 @@ class Domain_Check_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 		$domain_names = new Entity\Domain_Names();
 		$domain_names->add_domain_name( new Entity\Domain_Name( 'test-domain-name-1.com' ) )
 			->add_domain_name( new Entity\Domain_Name( 'test-domain-name-2.com' ) )
-			->add_domain_name( new Entity\Domain_Name( 'test-domain-name-3.com' ) );
+			->add_domain_name( new Entity\Domain_Name( 'test-domain-name-3.com' ) )
+			->add_domain_name( new Entity\Domain_Name( 'test-domain-name-tld-in-maintenance.blog' ) );
 		$command = new Command\Domain\Check( $domain_names );
 
 		$response_data = [
@@ -43,18 +44,28 @@ class Domain_Check_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 						'fee_class' => 'standard',
 						'fee_amount' => 12.34,
 						'zone_is_active' => true,
+						'tld_in_maintenance' => false,
 					],
 					'test-domain-name-2.com' => [
 						'available' => true,
 						'fee_class' => 'standard',
 						'fee_amount' => 12.34,
 						'zone_is_active' => true,
+						'tld_in_maintenance' => false,
 					],
 					'test-domain-name-3.com' => [
 						'available' => false,
 						'fee_class' => 'standard',
 						'fee_amount' => 12.34,
 						'zone_is_active' => true,
+						'tld_in_maintenance' => false,
+					],
+					'test-domain-name-tld-in-maintenance.blog' => [
+						'available' => false,
+						'fee_class' => '',
+						'fee_amount' => 0,
+						'zone_is_active' => true,
+						'tld_in_maintenance' => true,
 					],
 				],
 			],


### PR DESCRIPTION
This PR adds the `tld_in_maintenance` property to the `Domain\Check` docs and unit tests.

### Testing

Ensure unit tests are running:

```
./vendor/bin/phpunit -c ./test/phpunit.xml
```