### PR TITLE
Fix missing import and typo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,4 +6,4 @@
 
 
 --------
-> This document was automatically generated from source code comments on 2023-05-26
+> This document was automatically generated from source code comments on 2023-06-07

--- a/docs/classes/Automattic-Domain-Services-Client-Response-Domain-Info.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Response-Domain-Info.md
@@ -21,7 +21,7 @@ attributes of the domain at the registry.
 * public [get_created_date()](#method_get_created_date)
 * public [get_data_by_key()](#method_get_data_by_key)
 * public [get_dnssec()](#method_get_dnssec)
-* public [get_dnssec_ds_dsata()](#method_get_dnssec_ds_dsata)
+* public [get_dnssec_ds_data()](#method_get_dnssec_ds_data)
 * public [get_domain_status()](#method_get_domain_status)
 * public [get_expiration_date()](#method_get_expiration_date)
 * public [get_name_servers()](#method_get_name_servers)
@@ -203,11 +203,11 @@ string|null
 
 ---
 
-<a id="method_get_dnssec_ds_dsata"></a>
-### get_dnssec_ds_dsata
+<a id="method_get_dnssec_ds_data"></a>
+### get_dnssec_ds_data
 
 ```
-public get_dnssec_ds_dsata() : string|null
+public get_dnssec_ds_data() : string|null
 ```
 
 ##### Summary

--- a/lib/exception/event/invalid-event-name.php
+++ b/lib/exception/event/invalid-event-name.php
@@ -18,7 +18,7 @@
 
 namespace Automattic\Domain_Services_Client\Exception\Event;
 
-use Automattic\Domain_Services_Client\{Exception};
+use Automattic\Domain_Services_Client\{Exception, Response};
 
 /**
  * Exception thrown when an invalid event name is used.

--- a/lib/response/domain/info.php
+++ b/lib/response/domain/info.php
@@ -83,7 +83,7 @@ class Info implements Response\Response_Interface {
 	 *
 	 * @return string|null
 	 */
-	public function get_dnssec_ds_dsata(): ?string {
+	public function get_dnssec_ds_data(): ?string {
 		return $this->get_data_by_key( 'data.dnssec_ds_data' );
 	}
 

--- a/test/response/domain-info-test.php
+++ b/test/response/domain-info-test.php
@@ -91,7 +91,7 @@ class Domain_Info_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 		$this->assertEquals( $mock_response_data['data']['created_date'], Helper\Date_Time::format( $response_object->get_created_date() ) );
 		$this->assertEquals( $mock_response_data['data']['expiration_date'], Helper\Date_Time::format( $response_object->get_expiration_date() ) );
 		$this->assertEquals( $mock_response_data['data']['dnssec'], $response_object->get_dnssec() );
-		$this->assertEquals( $mock_response_data['data']['dnssec_ds_data'], $response_object->get_dnssec_ds_dsata() );
+		$this->assertEquals( $mock_response_data['data']['dnssec_ds_data'], $response_object->get_dnssec_ds_data() );
 		$this->assertEquals( $mock_response_data['data']['domain_status'], $response_object->get_domain_status()->to_array() );
 		$this->assertEquals( $mock_response_data['data']['name_servers'], $response_object->get_name_servers()->to_array() );
 		$this->assertEquals( $mock_response_data['data']['paid_until'], Helper\Date_Time::format( $response_object->get_paid_until() ) );


### PR DESCRIPTION
An import was missing in the `Invalid_Event_Name` exception class and there was a typo in the `Response\Domain\Info::get_dnssec_ds_data` method name.

### Testing

Ensure all unit tests are passing:

```
./vendor/bin/phpunit -c ./test/phpunit.xml
```