### PR TITLE
Rename domain transfer events

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,4 +6,4 @@
 
 
 --------
-> This document was automatically generated from source code comments on 2023-06-22
+> This document was automatically generated from source code comments on 2023-07-21

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-In-Completed.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-In-Completed.md
@@ -1,14 +1,12 @@
-# Class: [\Automattic](../namespaces/automattic.md)[\Domain_Services_Client](../namespaces/automattic-domain-services-client.md)[\Event](../namespaces/automattic-domain-services-client-event.md)[\Domain](../namespaces/automattic-domain-services-client-event-domain.md)[\Transfer](../namespaces/automattic-domain-services-client-event-domain-transfer.md)[\In](../namespaces/automattic-domain-services-client-event-domain-transfer-in.md)\Fail
+# Class: [\Automattic](../namespaces/automattic.md)[\Domain_Services_Client](../namespaces/automattic-domain-services-client.md)[\Event](../namespaces/automattic-domain-services-client-event.md)[\Domain](../namespaces/automattic-domain-services-client-event-domain.md)[\Transfer](../namespaces/automattic-domain-services-client-event-domain-transfer.md)[\In](../namespaces/automattic-domain-services-client-event-domain-transfer-in.md)\Completed
 
 ## Summary:
 
-Inbound domain transfer failure event
+Inbound domain transfer success event
 
 ## Description:
 
-- This event is generated when a domain transfer from another registrar to the reseller's account fails after it was
-  successfully started
-- There might be more information about the cause of the failure in the event data
+This event is generated when a domain transfer from another registrar to the reseller's account is successful.
 
 
 ---
@@ -26,12 +24,13 @@ Inbound domain transfer failure event
 * public [get_request_date()](#method_get_request_date)
 * public [get_requesting_registrar()](#method_get_requesting_registrar)
 * public [get_transfer_status()](#method_get_transfer_status)
+* public [get_transferlocked_until_date()](#method_get_transferlocked_until_date)
 
 ---
 
 ### Details
 
-* File: [lib/event/domain/transfer/in/fail.php](../../lib/event/domain/transfer/in/fail.php)
+* File: [lib/event/domain/transfer/in/completed.php](../../lib/event/domain/transfer/in/completed.php)
 * Implements:
   * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
   * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
@@ -39,6 +38,7 @@ Inbound domain transfer failure event
   * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Transfer_Trait](../classes/Automattic-Domain-Services-Client-Event-Transfer-Trait.md)
+  * [\Automattic\Domain_Services_Client\Event\TransferLocked_Trait](../classes/Automattic-Domain-Services-Client-Event-TransferLocked-Trait.md)
 
 ---
 
@@ -249,4 +249,23 @@ Gets the status of the transfer.
 
 ```
 string|null
+```
+
+---
+
+<a id="method_get_transferlocked_until_date"></a>
+### get_transferlocked_until_date
+
+```
+public get_transferlocked_until_date() : \DateTimeInterface|null
+```
+
+##### Summary
+
+Gets the date until when the domain is transfer locked
+
+##### Returns:
+
+```
+\DateTimeInterface|null
 ```

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-In-Rejected.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-In-Rejected.md
@@ -1,12 +1,14 @@
-# Class: [\Automattic](../namespaces/automattic.md)[\Domain_Services_Client](../namespaces/automattic-domain-services-client.md)[\Event](../namespaces/automattic-domain-services-client-event.md)[\Domain](../namespaces/automattic-domain-services-client-event-domain.md)[\Transfer](../namespaces/automattic-domain-services-client-event-domain-transfer.md)[\Out](../namespaces/automattic-domain-services-client-event-domain-transfer-out.md)\Success
+# Class: [\Automattic](../namespaces/automattic.md)[\Domain_Services_Client](../namespaces/automattic-domain-services-client.md)[\Event](../namespaces/automattic-domain-services-client-event.md)[\Domain](../namespaces/automattic-domain-services-client-event-domain.md)[\Transfer](../namespaces/automattic-domain-services-client-event-domain-transfer.md)[\In](../namespaces/automattic-domain-services-client-event-domain-transfer-in.md)\Rejected
 
 ## Summary:
 
-Outbound domain transfer success event
+Inbound domain transfer failure event
 
 ## Description:
 
-This event is generated when a domain transfer to another registrar is successful.
+- This event is generated when a domain transfer from another registrar to the reseller's account fails after it was
+  successfully started
+- There might be more information about the cause of the failure in the event data
 
 
 ---
@@ -29,7 +31,7 @@ This event is generated when a domain transfer to another registrar is successfu
 
 ### Details
 
-* File: [lib/event/domain/transfer/out/success.php](../../lib/event/domain/transfer/out/success.php)
+* File: [lib/event/domain/transfer/in/rejected.php](../../lib/event/domain/transfer/in/rejected.php)
 * Implements:
   * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
   * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-Out-Completed.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-Out-Completed.md
@@ -1,13 +1,12 @@
-# Class: [\Automattic](../namespaces/automattic.md)[\Domain_Services_Client](../namespaces/automattic-domain-services-client.md)[\Event](../namespaces/automattic-domain-services-client-event.md)[\Domain](../namespaces/automattic-domain-services-client-event-domain.md)[\Transfer](../namespaces/automattic-domain-services-client-event-domain-transfer.md)[\Out](../namespaces/automattic-domain-services-client-event-domain-transfer-out.md)\Fail
+# Class: [\Automattic](../namespaces/automattic.md)[\Domain_Services_Client](../namespaces/automattic-domain-services-client.md)[\Event](../namespaces/automattic-domain-services-client-event.md)[\Domain](../namespaces/automattic-domain-services-client-event-domain.md)[\Transfer](../namespaces/automattic-domain-services-client-event-domain-transfer.md)[\Out](../namespaces/automattic-domain-services-client-event-domain-transfer-out.md)\Completed
 
 ## Summary:
 
-Outbound domain transfer failure event
+Outbound domain transfer success event
 
 ## Description:
 
-- This event is generated when a domain transfer to another registrar fails after it was successfully started
-- There might be more information about the cause of the failure in the event data
+This event is generated when a domain transfer to another registrar is successful.
 
 
 ---
@@ -30,7 +29,7 @@ Outbound domain transfer failure event
 
 ### Details
 
-* File: [lib/event/domain/transfer/out/fail.php](../../lib/event/domain/transfer/out/fail.php)
+* File: [lib/event/domain/transfer/out/completed.php](../../lib/event/domain/transfer/out/completed.php)
 * Implements:
   * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
   * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)

--- a/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-Out-Rejected.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-Out-Rejected.md
@@ -1,12 +1,13 @@
-# Class: [\Automattic](../namespaces/automattic.md)[\Domain_Services_Client](../namespaces/automattic-domain-services-client.md)[\Event](../namespaces/automattic-domain-services-client-event.md)[\Domain](../namespaces/automattic-domain-services-client-event-domain.md)[\Transfer](../namespaces/automattic-domain-services-client-event-domain-transfer.md)[\In](../namespaces/automattic-domain-services-client-event-domain-transfer-in.md)\Success
+# Class: [\Automattic](../namespaces/automattic.md)[\Domain_Services_Client](../namespaces/automattic-domain-services-client.md)[\Event](../namespaces/automattic-domain-services-client-event.md)[\Domain](../namespaces/automattic-domain-services-client-event-domain.md)[\Transfer](../namespaces/automattic-domain-services-client-event-domain-transfer.md)[\Out](../namespaces/automattic-domain-services-client-event-domain-transfer-out.md)\Rejected
 
 ## Summary:
 
-Inbound domain transfer success event
+Outbound domain transfer failure event
 
 ## Description:
 
-This event is generated when a domain transfer from another registrar to the reseller's account is successful.
+- This event is generated when a domain transfer to another registrar fails after it was successfully started
+- There might be more information about the cause of the failure in the event data
 
 
 ---
@@ -24,13 +25,12 @@ This event is generated when a domain transfer from another registrar to the res
 * public [get_request_date()](#method_get_request_date)
 * public [get_requesting_registrar()](#method_get_requesting_registrar)
 * public [get_transfer_status()](#method_get_transfer_status)
-* public [get_transferlocked_until_date()](#method_get_transferlocked_until_date)
 
 ---
 
 ### Details
 
-* File: [lib/event/domain/transfer/in/success.php](../../lib/event/domain/transfer/in/success.php)
+* File: [lib/event/domain/transfer/out/rejected.php](../../lib/event/domain/transfer/out/rejected.php)
 * Implements:
   * [\Automattic\Domain_Services_Client\Event\Event_Interface](../classes/Automattic-Domain-Services-Client-Event-Event-Interface.md)
   * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Interface](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Interface.md)
@@ -38,7 +38,6 @@ This event is generated when a domain transfer from another registrar to the res
   * [\Automattic\Domain_Services_Client\Event\Async_Command_Related_Trait](../classes/Automattic-Domain-Services-Client-Event-Async-Command-Related-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Object_Type_Domain_Trait](../classes/Automattic-Domain-Services-Client-Event-Object-Type-Domain-Trait.md)
   * [\Automattic\Domain_Services_Client\Event\Transfer_Trait](../classes/Automattic-Domain-Services-Client-Event-Transfer-Trait.md)
-  * [\Automattic\Domain_Services_Client\Event\TransferLocked_Trait](../classes/Automattic-Domain-Services-Client-Event-TransferLocked-Trait.md)
 
 ---
 
@@ -249,23 +248,4 @@ Gets the status of the transfer.
 
 ```
 string|null
-```
-
----
-
-<a id="method_get_transferlocked_until_date"></a>
-### get_transferlocked_until_date
-
-```
-public get_transferlocked_until_date() : \DateTimeInterface|null
-```
-
-##### Summary
-
-Gets the date until when the domain is transfer locked
-
-##### Returns:
-
-```
-\DateTimeInterface|null
 ```

--- a/docs/namespaces/automattic-domain-services-client-event-domain-transfer-in.md
+++ b/docs/namespaces/automattic-domain-services-client-event-domain-transfer-in.md
@@ -4,6 +4,6 @@
 
 | Name | Summary |
 |------|---------|
-| [\Automattic\Domain_Services_Client\Event\Domain\Transfer\In\Fail](../classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-In-Fail.md) | Inbound domain transfer failure event |
+| [\Automattic\Domain_Services_Client\Event\Domain\Transfer\In\Completed](../classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-In-Completed.md) | Inbound domain transfer success event |
 | [\Automattic\Domain_Services_Client\Event\Domain\Transfer\In\Pending](../classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-In-Pending.md) | Inbound domain transfer start event |
-| [\Automattic\Domain_Services_Client\Event\Domain\Transfer\In\Success](../classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-In-Success.md) | Inbound domain transfer success event |
+| [\Automattic\Domain_Services_Client\Event\Domain\Transfer\In\Rejected](../classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-In-Rejected.md) | Inbound domain transfer failure event |

--- a/docs/namespaces/automattic-domain-services-client-event-domain-transfer-out.md
+++ b/docs/namespaces/automattic-domain-services-client-event-domain-transfer-out.md
@@ -4,6 +4,6 @@
 
 | Name | Summary |
 |------|---------|
-| [\Automattic\Domain_Services_Client\Event\Domain\Transfer\Out\Fail](../classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-Out-Fail.md) | Outbound domain transfer failure event |
+| [\Automattic\Domain_Services_Client\Event\Domain\Transfer\Out\Completed](../classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-Out-Completed.md) | Outbound domain transfer success event |
 | [\Automattic\Domain_Services_Client\Event\Domain\Transfer\Out\Pending](../classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-Out-Pending.md) | Outbound domain transfer start event |
-| [\Automattic\Domain_Services_Client\Event\Domain\Transfer\Out\Success](../classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-Out-Success.md) | Outbound domain transfer success event |
+| [\Automattic\Domain_Services_Client\Event\Domain\Transfer\Out\Rejected](../classes/Automattic-Domain-Services-Client-Event-Domain-Transfer-Out-Rejected.md) | Outbound domain transfer failure event |

--- a/lib/event/domain/transfer/in/completed.php
+++ b/lib/event/domain/transfer/in/completed.php
@@ -16,18 +16,18 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services_Client\Event\Domain\Transfer\Out;
+namespace Automattic\Domain_Services_Client\Event\Domain\Transfer\In;
 
 use Automattic\Domain_Services_Client\{Event};
 
 /**
- * Outbound domain transfer failure event
+ * Inbound domain transfer success event
  *
- * - This event is generated when a domain transfer to another registrar fails after it was successfully started
- * - There might be more information about the cause of the failure in the event data
+ * This event is generated when a domain transfer from another registrar to the reseller's account is successful.
  */
-class Fail implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+class Completed implements Event\Event_Interface, Event\Async_Command_Related_Interface {
 	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
 	use Event\Transfer_Trait;
+	use Event\TransferLocked_Trait;
 }

--- a/lib/event/domain/transfer/in/rejected.php
+++ b/lib/event/domain/transfer/in/rejected.php
@@ -27,7 +27,7 @@ use Automattic\Domain_Services_Client\{Event};
  *   successfully started
  * - There might be more information about the cause of the failure in the event data
  */
-class Fail implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+class Rejected implements Event\Event_Interface, Event\Async_Command_Related_Interface {
 	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
 	use Event\Transfer_Trait;

--- a/lib/event/domain/transfer/out/completed.php
+++ b/lib/event/domain/transfer/out/completed.php
@@ -16,18 +16,17 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-namespace Automattic\Domain_Services_Client\Event\Domain\Transfer\In;
+namespace Automattic\Domain_Services_Client\Event\Domain\Transfer\Out;
 
 use Automattic\Domain_Services_Client\{Event};
 
 /**
- * Inbound domain transfer success event
+ * Outbound domain transfer success event
  *
- * This event is generated when a domain transfer from another registrar to the reseller's account is successful.
+ * This event is generated when a domain transfer to another registrar is successful.
  */
-class Success implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+class Completed implements Event\Event_Interface, Event\Async_Command_Related_Interface {
 	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
 	use Event\Transfer_Trait;
-	use Event\TransferLocked_Trait;
 }

--- a/lib/event/domain/transfer/out/rejected.php
+++ b/lib/event/domain/transfer/out/rejected.php
@@ -21,11 +21,12 @@ namespace Automattic\Domain_Services_Client\Event\Domain\Transfer\Out;
 use Automattic\Domain_Services_Client\{Event};
 
 /**
- * Outbound domain transfer success event
+ * Outbound domain transfer failure event
  *
- * This event is generated when a domain transfer to another registrar is successful.
+ * - This event is generated when a domain transfer to another registrar fails after it was successfully started
+ * - There might be more information about the cause of the failure in the event data
  */
-class Success implements Event\Event_Interface, Event\Async_Command_Related_Interface {
+class Rejected implements Event\Event_Interface, Event\Async_Command_Related_Interface {
 	use Event\Async_Command_Related_Trait;
 	use Event\Object_Type_Domain_Trait;
 	use Event\Transfer_Trait;

--- a/test/event/domain-transfer-in-completed-test.php
+++ b/test/event/domain-transfer-in-completed-test.php
@@ -20,7 +20,7 @@ namespace Automattic\Domain_Services_Client\Test\Event;
 
 use Automattic\Domain_Services_Client\{Command, Helper, Event, Response, Test};
 
-class Domain_Transfer_Out_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case {
+class Domain_Transfer_In_Success_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {
 		$command = new Command\Event\Details( 1234 );
 
@@ -35,19 +35,19 @@ class Domain_Transfer_Out_Fail_Test extends Test\Lib\Domain_Services_Client_Test
 			'data' => [
 				'event' => [
 					'id' => 1234,
-					'event_class' => 'Domain\Transfer\Out',
-					'event_subclass' => 'Fail',
+					'event_class' => 'Domain\Transfer\In',
+					'event_subclass' => 'Completed',
 					'object_type' => 'domain',
 					'object_id' => 'example.com',
 					'event_date' => '2022-01-23 12:34:56',
 					'acknowledged_date' => null,
 					'event_data' => [
-						'current_registrar' => 'automattic',
-						'requesting_registrar' => 'gaining_registrar',
+						'current_registrar' => 'losing_registrar',
+						'requesting_registrar' => 'automattic',
 						'auto_nack' => false,
 						'request_date' => '2022-12-08 18:03:16',
 						'execute_date' => '2022-12-08 18:03:44',
-						'transfer_status' => 'clientRejected',
+						'transfer_status' => 'clientApproved',
 					],
 				],
 			],
@@ -61,7 +61,7 @@ class Domain_Transfer_Out_Fail_Test extends Test\Lib\Domain_Services_Client_Test
 		$event = $response_object->get_event();
 		$this->assertNotNull( $event );
 
-		$this->assertInstanceOf( Event\Domain\Transfer\Out\Fail::class, $event );
+		$this->assertInstanceOf( Event\Domain\Transfer\In\Completed::class, $event );
 		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['current_registrar'], $event->get_current_registrar() );
 		$this->assertSame( $response_data['data']['event']['event_data']['requesting_registrar'], $event->get_requesting_registrar() );

--- a/test/event/domain-transfer-in-rejected-test.php
+++ b/test/event/domain-transfer-in-rejected-test.php
@@ -20,7 +20,7 @@ namespace Automattic\Domain_Services_Client\Test\Event;
 
 use Automattic\Domain_Services_Client\{Command, Helper, Event, Response, Test};
 
-class Domain_Transfer_In_Success_Test extends Test\Lib\Domain_Services_Client_Test_Case {
+class Domain_Transfer_In_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {
 		$command = new Command\Event\Details( 1234 );
 
@@ -36,7 +36,7 @@ class Domain_Transfer_In_Success_Test extends Test\Lib\Domain_Services_Client_Te
 				'event' => [
 					'id' => 1234,
 					'event_class' => 'Domain\Transfer\In',
-					'event_subclass' => 'Success',
+					'event_subclass' => 'Rejected',
 					'object_type' => 'domain',
 					'object_id' => 'example.com',
 					'event_date' => '2022-01-23 12:34:56',
@@ -47,7 +47,7 @@ class Domain_Transfer_In_Success_Test extends Test\Lib\Domain_Services_Client_Te
 						'auto_nack' => false,
 						'request_date' => '2022-12-08 18:03:16',
 						'execute_date' => '2022-12-08 18:03:44',
-						'transfer_status' => 'clientApproved',
+						'transfer_status' => 'clientRejected',
 					],
 				],
 			],
@@ -61,7 +61,7 @@ class Domain_Transfer_In_Success_Test extends Test\Lib\Domain_Services_Client_Te
 		$event = $response_object->get_event();
 		$this->assertNotNull( $event );
 
-		$this->assertInstanceOf( Event\Domain\Transfer\In\Success::class, $event );
+		$this->assertInstanceOf( Event\Domain\Transfer\In\Rejected::class, $event );
 		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['current_registrar'], $event->get_current_registrar() );
 		$this->assertSame( $response_data['data']['event']['event_data']['requesting_registrar'], $event->get_requesting_registrar() );

--- a/test/event/domain-transfer-out-rejected-test.php
+++ b/test/event/domain-transfer-out-rejected-test.php
@@ -20,7 +20,7 @@ namespace Automattic\Domain_Services_Client\Test\Event;
 
 use Automattic\Domain_Services_Client\{Command, Helper, Event, Response, Test};
 
-class Domain_Transfer_In_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case {
+class Domain_Transfer_Out_Fail_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 	public function test_event_success(): void {
 		$command = new Command\Event\Details( 1234 );
 
@@ -35,15 +35,15 @@ class Domain_Transfer_In_Fail_Test extends Test\Lib\Domain_Services_Client_Test_
 			'data' => [
 				'event' => [
 					'id' => 1234,
-					'event_class' => 'Domain\Transfer\In',
-					'event_subclass' => 'Fail',
+					'event_class' => 'Domain\Transfer\Out',
+					'event_subclass' => 'Rejected',
 					'object_type' => 'domain',
 					'object_id' => 'example.com',
 					'event_date' => '2022-01-23 12:34:56',
 					'acknowledged_date' => null,
 					'event_data' => [
-						'current_registrar' => 'losing_registrar',
-						'requesting_registrar' => 'automattic',
+						'current_registrar' => 'automattic',
+						'requesting_registrar' => 'gaining_registrar',
 						'auto_nack' => false,
 						'request_date' => '2022-12-08 18:03:16',
 						'execute_date' => '2022-12-08 18:03:44',
@@ -61,7 +61,7 @@ class Domain_Transfer_In_Fail_Test extends Test\Lib\Domain_Services_Client_Test_
 		$event = $response_object->get_event();
 		$this->assertNotNull( $event );
 
-		$this->assertInstanceOf( Event\Domain\Transfer\In\Fail::class, $event );
+		$this->assertInstanceOf( Event\Domain\Transfer\Out\Rejected::class, $event );
 		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['current_registrar'], $event->get_current_registrar() );
 		$this->assertSame( $response_data['data']['event']['event_data']['requesting_registrar'], $event->get_requesting_registrar() );

--- a/test/event/domain-transfer-out-success-test.php
+++ b/test/event/domain-transfer-out-success-test.php
@@ -36,7 +36,7 @@ class Domain_Transfer_Out_Success_Test extends Test\Lib\Domain_Services_Client_T
 				'event' => [
 					'id' => 1234,
 					'event_class' => 'Domain\Transfer\Out',
-					'event_subclass' => 'Success',
+					'event_subclass' => 'Completed',
 					'object_type' => 'domain',
 					'object_id' => 'example.com',
 					'event_date' => '2022-01-23 12:34:56',
@@ -61,7 +61,7 @@ class Domain_Transfer_Out_Success_Test extends Test\Lib\Domain_Services_Client_T
 		$event = $response_object->get_event();
 		$this->assertNotNull( $event );
 
-		$this->assertInstanceOf( Event\Domain\Transfer\Out\Success::class, $event );
+		$this->assertInstanceOf( Event\Domain\Transfer\Out\Completed::class, $event );
 		$this->assertIsValidEvent( $response_data['data']['event'], $event );
 		$this->assertSame( $response_data['data']['event']['event_data']['current_registrar'], $event->get_current_registrar() );
 		$this->assertSame( $response_data['data']['event']['event_data']['requesting_registrar'], $event->get_requesting_registrar() );


### PR DESCRIPTION
This PR renames all `Domain\Transfer\[In|Out]` events:

- `Domain\Transfer\Out\Fail` -> `Domain\Transfer\Out\Rejected`
- `Domain\Transfer\Out\Success` -> `Domain\Transfer\Out\Completed`
- `Domain\Transfer\In\Fail` -> `Domain\Transfer\In\Rejected`
- `Domain\Transfer\In\Success` -> `Domain\Transfer\In\Completed`

```
$ composer install
$ ./vendor/bin/phpunit -c ./test/phpunit.xml
```
