### PR TITLE
Add `domain` parameter to `Dns\Set` command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,4 +6,4 @@
 
 
 --------
-> This document was automatically generated from source code comments on 2023-08-11
+> This document was automatically generated from source code comments on 2023-08-18

--- a/docs/classes/Automattic-Domain-Services-Client-Command-Dns-Set.md
+++ b/docs/classes/Automattic-Domain-Services-Client-Command-Dns-Set.md
@@ -31,7 +31,7 @@ $records_array = [
 $dns_record_sets = Entity\Dns_Record_Sets::from_array( $records_array );
 
 $dns_records = new Entity\Dns_Records( $domain_name, $dns_record_sets );
-$command = new Command\Dns\Set( $dns_records );
+$command = new Command\Dns\Set( $domain_name, $dns_records );
 
 $response = $api->post( $command );
 
@@ -68,7 +68,7 @@ if ( $response->is_success() ) {
 ### __construct
 
 ```
-public __construct(\Automattic\Domain_Services_Client\Entity\Dns_Records  records) : mixed
+public __construct(\Automattic\Domain_Services_Client\Entity\Domain_Name  domain, \Automattic\Domain_Services_Client\Entity\Dns_Records  records) : mixed
 ```
 
 ##### Summary
@@ -79,6 +79,7 @@ Constructs a `Dns\Set` command
 
 | Name | Type | Default |
 |------|------|---------|
+| **$domain** | \Automattic\Domain_Services_Client\Entity\Domain_Name |  |
 | **$records** | \Automattic\Domain_Services_Client\Entity\Dns_Records |  |
 
 ##### Returns:

--- a/lib/command/dns/set.php
+++ b/lib/command/dns/set.php
@@ -48,7 +48,7 @@ use Automattic\Domain_Services_Client\{Command, Entity};
  * $dns_record_sets = Entity\Dns_Record_Sets::from_array( $records_array );
  *
  * $dns_records = new Entity\Dns_Records( $domain_name, $dns_record_sets );
- * $command = new Command\Dns\Set( $dns_records );
+ * $command = new Command\Dns\Set( $domain_name, $dns_records );
  *
  * $response = $api->post( $command );
  *
@@ -67,6 +67,13 @@ class Set implements Command\Command_Interface, Command\Command_Serialize_Interf
 	use Command\Command_Trait;
 
 	/**
+	 * The domain name whose DNS records will be set
+	 *
+	 * @var Entity\Domain_Name
+	 */
+	private Entity\Domain_Name $domain;
+
+	/**
 	 * DNS records that will be set at the server
 	 *
 	 * @var Entity\Dns_Records
@@ -78,8 +85,18 @@ class Set implements Command\Command_Interface, Command\Command_Serialize_Interf
 	 *
 	 * @param Entity\Dns_Records $records
 	 */
-	public function __construct( Entity\Dns_Records $records ) {
+	public function __construct( Entity\Domain_Name $domain, Entity\Dns_Records $records ) {
+		$this->domain = $domain;
 		$this->records = $records;
+	}
+
+	/**
+	 * Returns the domain name whose DNS records will be set
+	 *
+	 * @return Entity\Domain_Name
+	 */
+	private function get_domain(): Entity\Domain_Name {
+		return $this->domain;
 	}
 
 	/**
@@ -100,6 +117,7 @@ class Set implements Command\Command_Interface, Command\Command_Serialize_Interf
 	 */
 	public function to_array(): array {
 		return [
+			Command\Command_Interface::KEY_DOMAIN => $this->get_domain()->get_name(),
 			Command\Command_Interface::KEY_RECORDS => $this->get_records()->to_array(),
 		];
 	}

--- a/test/command/dns-set-test.php
+++ b/test/command/dns-set-test.php
@@ -26,6 +26,7 @@ class Dns_Set_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 		$mock_command_data = [
 			Command\Command_Interface::COMMAND => 'Dns\Set',
 			Command\Command_Interface::PARAMS => [
+				Command\Command_Interface::KEY_DOMAIN => 'test-domain-name.com',
 				Command\Command_Interface::KEY_RECORDS => [
 					Command\Command_Interface::KEY_DOMAIN => 'test-domain-name.com',
 					Command\Command_Interface::KEY_RECORD_SETS => [
@@ -53,7 +54,8 @@ class Dns_Set_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 		];
 
 		$dns_records = Entity\Dns_Records::from_array( $mock_command_data[ Command\Command_Interface::PARAMS ][ Command\Command_Interface::KEY_RECORDS ] );
-		$command = new Command\Dns\Set( $dns_records );
+		$domain = new Entity\Domain_Name( $mock_command_data[ Command\Command_Interface::PARAMS ][ Command\Command_Interface::KEY_DOMAIN ] );
+		$command = new Command\Dns\Set( $domain, $dns_records );
 		$command->set_client_txn_id( $mock_command_data[ Command\Command_Interface::CLIENT_TXN_ID ] );
 
 		$this->assertInstanceOf( Command\Dns\Set::class, $command );

--- a/test/response/dns-set-test.php
+++ b/test/response/dns-set-test.php
@@ -46,7 +46,7 @@ class Dns_Set_Test extends Test\Lib\Domain_Services_Client_Test_Case {
 			],
 		);
 		$dns_records = new Entity\Dns_Records( $domain, $dns_record_sets );
-		$command = new Command\Dns\Set( $dns_records );
+		$command = new Command\Dns\Set( $domain, $dns_records );
 
 		$response_data = [
 			'data' => [


### PR DESCRIPTION
This PR updates the `Dns\Set` command adding a new parameter (`domain`).

```
./vendor/bin/phpunit -c ./test/phpunit.xml
```