### PR TITLE
Test on PHP 8.4, fix issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,59 @@
+# yamllint disable rule:line-length
+# yamllint disable rule:braces
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - trunk
+
+jobs:
+  tests:
+    name: Test with PHP ${{ matrix.php-version }} ${{ matrix.dependencies }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-version:
+          - '7.4'
+          - '8.0'
+          - '8.1'
+          - '8.2'
+          - '8.3'
+          - '8.4'
+        coverage: ['pcov']
+        dependencies: ['']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: ${{ matrix.coverage }}
+          tools: composer:v2
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/composer
+          key: composer-${{ matrix.php-version }}-${{ hashFiles('composer.*') }}
+          restore-keys: |
+            composer-${{ matrix.php-version }}-
+            composer-
+
+      - name: Install dependencies
+        run: |
+          composer update --prefer-dist --no-interaction --no-progress ${{ matrix.dependencies }}
+
+      - name: Set up tools
+        run: |
+          ./build.sh
+
+      - name: Execute tests
+        run: |
+          ./vendor/bin/phpunit -c ./test/phpunit.xml

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ phpdoc_dir=".phpdoc"
 phpcs="phpcs"
 
 # This makes sure we are always using the same version and only explicitly update it when we want to.
-phpdoc_version="3.3.1"
+phpdoc_version="3.7.1"
 phpdoc_exec="./dev-tools/phpDocumentor.phar"
 
 function main {

--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,8 @@
     "classmap": [
       "test/"
     ]
+  },
+  "config": {
+    "allow-plugins": false
   }
 }

--- a/lib/configuration.php
+++ b/lib/configuration.php
@@ -497,7 +497,7 @@ class Configuration {
 	 * @param array|null $variables hash of variable and the corresponding value (optional)
 	 * @return string URL based on host settings
 	 */
-	public function get_host_from_settings( int $index, array $variables = null ): string {
+	public function get_host_from_settings( int $index, ?array $variables = null ): string {
 		return self::get_host_string( $this->get_host_settings(), $index, $variables );
 	}
 }

--- a/lib/exception/domain-services-exception.php
+++ b/lib/exception/domain-services-exception.php
@@ -31,7 +31,7 @@ class Domain_Services_Exception extends \Exception {
 	 *
 	 * @internal
 	 */
-	public function __construct( int $code, array $data, ?\Throwable $previous = null ) {
+	public function __construct( int $code, array $data, \Throwable $previous = null ) {
 		$this->data = $data;
 		parent::__construct( Response\Code::get_description( $code ), $code, $previous );
 	}

--- a/lib/exception/domain-services-exception.php
+++ b/lib/exception/domain-services-exception.php
@@ -31,7 +31,7 @@ class Domain_Services_Exception extends \Exception {
 	 *
 	 * @internal
 	 */
-	public function __construct( int $code, array $data, \Throwable $previous = null ) {
+	public function __construct( int $code, array $data, ?\Throwable $previous = null ) {
 		$this->data = $data;
 		parent::__construct( Response\Code::get_description( $code ), $code, $previous );
 	}

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -25,6 +25,9 @@
 		convertWarningsToExceptions="true"
 		convertDeprecationsToExceptions="true"
 		bootstrap="bootstrap.php">
+	<php>
+		<ini name="error_reporting" value="E_ALL"/>
+	</php>
 	<testsuites>
 		<testsuite name="command">
 			<directory suffix="test.php">command</directory>

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -21,8 +21,9 @@
 		timeoutForSmallTests="25"
 		timeoutForMediumTests="50"
 		timeoutForLargeTests="120"
-		convertNoticesToExceptions="false"
-		convertWarningsToExceptions="false"
+		convertNoticesToExceptions="true"
+		convertWarningsToExceptions="true"
+		convertDeprecationsToExceptions="true"
 		bootstrap="bootstrap.php">
 	<testsuites>
 		<testsuite name="command">


### PR DESCRIPTION
I'm looking at:

```
% ./vendor/bin/phpunit -c ./test/phpunit.xml 
PHPUnit 9.6.22 by Sebastian Bergmann and contributors.

PHP Deprecated:  Automattic\Domain_Services_Client\Exception\Domain_Services_Exception::__construct(): Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead in /Users/lesha/PhpstormProjects/domain-services-client/lib/exception/domain-services-exception.php on line 34
........................
Deprecated: Automattic\Domain_Services_Client\Exception\Domain_Services_Exception::__construct(): Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead in lib/exception/domain-services-exception.php on line 34
.......................................  63 / 103 ( 61%)
PHP Deprecated:  Automattic\Domain_Services_Client\Configuration::get_host_from_settings(): Implicitly marking parameter $variables as nullable is deprecated, the explicit nullable type must be used instead in /Users/lesha/PhpstormProjects/domain-services-client/lib/configuration.php on line 500
........................................                        103 / 103 (100%)
Deprecated: Automattic\Domain_Services_Client\Configuration::get_host_from_settings(): Implicitly marking parameter $variables as nullable is deprecated, the explicit nullable type must be used instead in lib/configuration.php on line 500


Time: 00:00.014, Memory: 10.00 MB

OK (103 tests, 1263 assertions)
```

Try running ` ./vendor/bin/phpunit -c ./test/phpunit.xml ` to confirm these are all gone.