### PR TITLE
Fix missing dependency in the guzzle-7 example

### DIFF
--- a/dev-tools/examples/guzzle-7.php
+++ b/dev-tools/examples/guzzle-7.php
@@ -17,7 +17,7 @@
  * if not, see https://www.gnu.org/licenses.
  */
 
-use Automattic\Domain_Services_Client\{Api, Command, Configuration, Entity, Response, Exception};
+use Automattic\Domain_Services_Client\{Api, Command, Configuration, Entity, Request, Response, Exception};
 use GuzzleHttp\Psr7\HttpFactory;
 use GuzzleHttp\Client;
 


### PR DESCRIPTION
The guzzle-7 example code references the `Request` namespace item but that item isn't included in the `use` statement. This adds it.

## Testing

Visual inspection should be fine.