### PR TITLE
Exclude dev tools from the release archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/.*         export-ignore
+/build.sh   export-ignore
+/*.xml      export-ignore
+/dev-tools  export-ignore
+/test       export-ignore


### PR DESCRIPTION
Let's exclude dev tools (which include a literal phpdocumentor.phar) and various tests from the release archives. Should be easy to validate with:

```
git archive --format=tar HEAD | tar t
```

(A branch from earlier that I missed to PR.)