### PR TITLE
fix: use supported GitHub Actions Dependabot cooldown config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,4 +20,3 @@ updates:
           - "major"
     cooldown:
       default-days: 7
-      semver-major-days: 14


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/domain-services-client/pull/210.

That PR added GitHub Actions Dependabot coverage with unsupported per-SemVer cooldown keys for the `github-actions` ecosystem. This removes the unsupported key(s) and keeps the supported flat `cooldown.default-days: 7` setting.

Removed: `semver-major-days: 14`.

Reference: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown

Tracking: DEVPROD-1072
